### PR TITLE
docs: Add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ It connects to **8 AI coding tools** via Unix socket IPC, displaying session sta
 
 ## Installation
 
-### Download (Recommended)
+### Homebrew (Recommended)
+
+```bash
+brew tap efan404/codeisland
+brew install --cask codeisland
+```
+
+### Download
 
 1. Go to [Releases](https://github.com/wxtsky/CodeIsland/releases)
 2. Download `CodeIsland.app.zip`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,7 +52,14 @@ CodeIsland 住在你 MacBook 的刘海区域，实时展示 AI 编码 Agent 的�
 
 ## 安装
 
-### 下载安装（推荐）
+### Homebrew 安装（推荐）
+
+```bash
+brew tap efan404/codeisland
+brew install --cask codeisland
+```
+
+### 下载安装
 
 1. 前往 [Releases](https://github.com/wxtsky/CodeIsland/releases) 页面
 2. 下载 `CodeIsland.app.zip`


### PR DESCRIPTION
## Summary

This PR adds Homebrew installation instructions to the README, making it easier for macOS users to install CodeIsland.

## Installation via Homebrew

```bash
brew tap efan404/codeisland
brew install --cask codeisland
```

## Notes

- This is a community-maintained Homebrew tap (https://github.com/Efan404/homebrew-codeisland)
- The tap includes automatic version checking (daily) to stay in sync with upstream releases
- Supports both Apple Silicon and Intel Macs

## Checklist

- [x] Added Homebrew installation as the recommended method
- [x] Preserved existing download instructions as alternative
- [x] Installation method is clearly documented