### PR TITLE
Fix idle mascot fallback for the most recently active CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,5 +22,10 @@ let package = Package(
             dependencies: ["CodeIslandCore"],
             path: "Sources/CodeIslandBridge"
         ),
+        .testTarget(
+            name: "CodeIslandCoreTests",
+            dependencies: ["CodeIslandCore"],
+            path: "Tests/CodeIslandCoreTests"
+        ),
     ]
 )

--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -356,35 +356,12 @@ final class AppState {
     /// Recompute cached status/source/counts from sessions in a single O(n) pass.
     /// Call after any mutation to `sessions` or session status.
     private func refreshDerivedState() {
-        var highestStatus: AgentStatus = .idle
-        var source = "claude"
-        var active = 0
-        for s in sessions.values {
-            if s.status != .idle { active += 1 }
-            switch s.status {
-            case .waitingApproval:
-                highestStatus = .waitingApproval; source = s.source
-            case .waitingQuestion:
-                if highestStatus != .waitingApproval {
-                    highestStatus = .waitingQuestion; source = s.source
-                }
-            case .running:
-                if highestStatus == .idle || highestStatus == .processing {
-                    highestStatus = .running; source = s.source
-                }
-            case .processing:
-                if highestStatus == .idle {
-                    highestStatus = .processing; source = s.source
-                }
-            default: break
-            }
-        }
+        let summary = deriveSessionSummary(from: sessions)
         // Only assign when changed (avoids unnecessary @Observable notifications)
-        if status != highestStatus { status = highestStatus }
-        if primarySource != source { primarySource = source }
-        if activeSessionCount != active { activeSessionCount = active }
-        let total = sessions.count
-        if totalSessionCount != total { totalSessionCount = total }
+        if status != summary.status { status = summary.status }
+        if primarySource != summary.primarySource { primarySource = summary.primarySource }
+        if activeSessionCount != summary.activeSessionCount { activeSessionCount = summary.activeSessionCount }
+        if totalSessionCount != summary.totalSessionCount { totalSessionCount = summary.totalSessionCount }
     }
 
     func handleEvent(_ event: HookEvent) {

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -158,6 +158,69 @@ public struct SessionSnapshot {
     }
 }
 
+public struct SessionSummary {
+    public let status: AgentStatus
+    public let primarySource: String
+    public let activeSessionCount: Int
+    public let totalSessionCount: Int
+
+    public init(status: AgentStatus, primarySource: String, activeSessionCount: Int, totalSessionCount: Int) {
+        self.status = status
+        self.primarySource = primarySource
+        self.activeSessionCount = activeSessionCount
+        self.totalSessionCount = totalSessionCount
+    }
+}
+
+public func deriveSessionSummary(from sessions: [String: SessionSnapshot]) -> SessionSummary {
+    var highestStatus: AgentStatus = .idle
+    var source = "claude"
+    var active = 0
+    var mostRecentIdleSource: (source: String, time: Date)?
+
+    for session in sessions.values {
+        if session.status != .idle {
+            active += 1
+        } else if mostRecentIdleSource == nil || session.lastActivity > mostRecentIdleSource!.time {
+            mostRecentIdleSource = (session.source, session.lastActivity)
+        }
+
+        switch session.status {
+        case .waitingApproval:
+            highestStatus = .waitingApproval
+            source = session.source
+        case .waitingQuestion:
+            if highestStatus != .waitingApproval {
+                highestStatus = .waitingQuestion
+                source = session.source
+            }
+        case .running:
+            if highestStatus == .idle || highestStatus == .processing {
+                highestStatus = .running
+                source = session.source
+            }
+        case .processing:
+            if highestStatus == .idle {
+                highestStatus = .processing
+                source = session.source
+            }
+        case .idle:
+            break
+        }
+    }
+
+    if highestStatus == .idle, let idleSource = mostRecentIdleSource?.source {
+        source = idleSource
+    }
+
+    return SessionSummary(
+        status: highestStatus,
+        primarySource: source,
+        activeSessionCount: active,
+        totalSessionCount: sessions.count
+    )
+}
+
 // MARK: - Side Effects
 
 public enum SideEffect: Equatable {

--- a/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
+++ b/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import CodeIslandCore
+
+final class DerivedSessionStateTests: XCTestCase {
+    func testAllIdleSessionsUseMostRecentlyActiveSource() {
+        var older = SessionSnapshot()
+        older.source = "claude"
+        older.status = .idle
+        older.lastActivity = Date(timeIntervalSince1970: 100)
+
+        var newer = SessionSnapshot()
+        newer.source = "codex"
+        newer.status = .idle
+        newer.lastActivity = Date(timeIntervalSince1970: 200)
+
+        let summary = deriveSessionSummary(from: [
+            "older": older,
+            "newer": newer,
+        ])
+
+        XCTAssertEqual(summary.primarySource, "codex")
+        XCTAssertEqual(summary.activeSessionCount, 0)
+        XCTAssertEqual(summary.totalSessionCount, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- keep the collapsed idle mascot aligned with the most recently active CLI instead of falling back to Claude when every session is idle
- extract shared session summary derivation so AppState keeps the existing non-idle priority rules while fixing the all-idle source case
- add a regression test target that locks the all-idle source selection behavior

## 中文说明
- 当所有会话都处于 idle 时，收起态顶部角色不再默认回退成 Claude，而是保持为最近一次活跃的 CLI 角色
- 抽出共享的会话归纳逻辑，让 AppState 保持现有的非 idle 优先级规则，同时修正 all-idle 场景下的来源选择
- 增加回归测试，锁定 all-idle 场景下顶部角色来源的选择行为

原本存在的问题，即使我只有 Codex 会话，在全部进入 idle 的时候仍回退为 ClaudeCode 的 gif：
<img width="1370" height="834" alt="3fe2f448-9d97-492b-bb8e-607b746f1d57" src="https://github.com/user-attachments/assets/f1871187-d3fb-4d61-943d-28badd65c1c8" />
<img width="804" height="422" alt="0cdd25e5fb80290eb109d3ac38a8afc6" src="https://github.com/user-attachments/assets/dc2ad4cf-fb7c-4890-952d-33739d497152" />
修复后，可正常显示最后一个活跃的 CLI 角色：
<img width="772" height="200" alt="image" src="https://github.com/user-attachments/assets/4beeb9d9-030e-4828-a4d6-a82161f23d97" />

## Test Plan
- [x] `swift test`
- [x] Run a Codex session, let it finish, and confirm the collapsed top bar keeps the Codex sleep mascot when all sessions are idle

## 测试说明
- [x] `swift test`
- [x] 实际运行一个 Codex 会话，等待其结束，并确认当所有会话都 idle 时，顶部收起态仍显示 Codex 的 sleep 动画