### PR TITLE
Add cmux terminal support

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -7,6 +7,7 @@ import CodeIslandCore
 struct TerminalActivator {
 
     private static let knownTerminals: [(name: String, bundleId: String)] = [
+        ("cmux", "com.cmuxterm.app"),
         ("Ghostty", "com.mitchellh.ghostty"),
         ("iTerm2", "com.googlecode.iterm2"),
         ("WezTerm", "com.github.wez.wezterm"),
@@ -285,7 +286,8 @@ struct TerminalActivator {
     private static func bringToFront(_ termApp: String) {
         let name: String
         let lower = termApp.lowercased()
-        if lower.contains("ghostty") { name = "Ghostty" }
+        if lower.contains("cmux") { name = "cmux" }
+        else if lower.contains("ghostty") { name = "Ghostty" }
         else if lower.contains("iterm") { name = "iTerm2" }
         else if lower.contains("terminal") || lower.contains("apple_terminal") { name = "Terminal" }
         else if lower.contains("wezterm") || lower.contains("wez") { name = "WezTerm" }

--- a/Sources/CodeIsland/TerminalVisibilityDetector.swift
+++ b/Sources/CodeIsland/TerminalVisibilityDetector.swift
@@ -25,8 +25,15 @@ struct TerminalVisibilityDetector {
     /// Fast check: is the session's terminal app the frontmost application?
     /// Safe to call from the main thread — no AppleScript or subprocess calls.
     static func isTerminalFrontmostForSession(_ session: SessionSnapshot) -> Bool {
-        guard let termApp = session.termApp else { return false }
         guard let frontApp = NSWorkspace.shared.frontmostApplication else { return false }
+
+        if let termBundleId = session.termBundleId?.lowercased(),
+           !termBundleId.isEmpty,
+           frontApp.bundleIdentifier?.lowercased() == termBundleId {
+            return true
+        }
+
+        guard let termApp = session.termApp else { return false }
 
         let frontName = frontApp.localizedName?.lowercased() ?? ""
         let bundleId = frontApp.bundleIdentifier?.lowercased() ?? ""

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -125,6 +125,7 @@ public struct SessionSnapshot {
         // Check bundle ID for terminal identification (more reliable than TERM_PROGRAM)
         if let bid = termBundleId {
             let lower = bid.lowercased()
+            if lower.contains("cmux") { return "cmux" }
             if lower.contains("warp") { return "Warp" }
             if lower.contains("ghostty") { return "Ghostty" }
             if lower.contains("iterm2") { return "iTerm2" }
@@ -135,6 +136,7 @@ public struct SessionSnapshot {
         // Fallback to TERM_PROGRAM
         guard let app = termApp else { return nil }
         let lower = app.lowercased()
+        if lower.contains("cmux") { return "cmux" }
         if lower.contains("ghostty") { return "Ghostty" }
         if lower.contains("iterm") { return "iTerm2" }
         if lower.contains("warp") { return "Warp" }


### PR DESCRIPTION
## Summary
- recognize cmux by bundle identifier instead of falling back to Ghostty heuristics
- bring cmux to the foreground for jump actions instead of trying to activate Ghostty
- use the terminal bundle id for frontmost-app detection so smart suppress works with cmux sessions