### PR TITLE
Ignore unsupported session sources

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -801,9 +801,10 @@ final class AppState {
         let cutoff = Date().addingTimeInterval(-30 * 60) // 30 minutes
         for p in persisted where p.lastActivity > cutoff {
             guard sessions[p.sessionId] == nil else { continue }
+            guard let source = SessionSnapshot.normalizedSupportedSource(p.source) else { continue }
             var snapshot = SessionSnapshot(startTime: p.startTime)
             snapshot.cwd = p.cwd
-            snapshot.source = p.source
+            snapshot.source = source
             snapshot.model = p.model
             snapshot.lastUserPrompt = p.lastUserPrompt
             snapshot.lastAssistantMessage = p.lastAssistantMessage

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -100,6 +100,12 @@ class HookServer {
             return
         }
 
+        if let rawSource = event.rawJSON["_source"] as? String,
+           SessionSnapshot.normalizedSupportedSource(rawSource) == nil {
+            sendResponse(connection: connection, data: Data("{}".utf8))
+            return
+        }
+
         if event.eventName == "PermissionRequest" {
             let sessionId = event.sessionId ?? "default"
             // AskUserQuestion is a question, not a permission — route to QuestionBar

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -1,6 +1,17 @@
 import Foundation
 
 public struct SessionSnapshot {
+    public static let supportedSources: Set<String> = [
+        "claude",
+        "codex",
+        "gemini",
+        "cursor",
+        "qoder",
+        "droid",
+        "codebuddy",
+        "opencode",
+    ]
+
     public var status: AgentStatus = .idle
     public var currentTool: String?
     public var toolDescription: String?
@@ -31,6 +42,13 @@ public struct SessionSnapshot {
 
     public init(startTime: Date = Date()) {
         self.startTime = startTime
+    }
+
+    public static func normalizedSupportedSource(_ source: String?) -> String? {
+        guard let source else { return nil }
+        let normalized = source.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty, supportedSources.contains(normalized) else { return nil }
+        return normalized
     }
 
     public var activeSubagentCount: Int {
@@ -377,7 +395,7 @@ public func reduceEvent(
         if let ppid = event.rawJSON["_ppid"] as? Int, ppid > 0 {
             sessions[sessionId]?.cliPid = pid_t(ppid)
         }
-        if let source = event.rawJSON["_source"] as? String, !source.isEmpty {
+        if let source = SessionSnapshot.normalizedSupportedSource(event.rawJSON["_source"] as? String) {
             sessions[sessionId]?.source = source
         }
         if let app = event.rawJSON["_term_app"] as? String, !app.isEmpty { sessions[sessionId]?.termApp = app }
@@ -511,7 +529,7 @@ public func extractMetadata(into sessions: inout [String: SessionSnapshot], sess
     if let ppid = event.rawJSON["_ppid"] as? Int, ppid > 0 {
         sessions[sessionId]?.cliPid = pid_t(ppid)
     }
-    if let source = event.rawJSON["_source"] as? String, !source.isEmpty {
+    if let source = SessionSnapshot.normalizedSupportedSource(event.rawJSON["_source"] as? String) {
         sessions[sessionId]?.source = source
     }
 }


### PR DESCRIPTION
## Summary
- drop hook events whose `_source` is not part of CodeIsland's supported tool list
- normalize accepted source names before storing them in session state
- skip restoring persisted sessions with unsupported sources so stale entries stop reappearing