### PR TITLE
fix: remove invalid PermissionDenied hook key from Claude Code config

### DIFF
--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -45,7 +45,6 @@ struct ConfigInstaller {
                 ("PostToolUse", 5, true),
                 ("PostToolUseFailure", 5, true),
                 ("PermissionRequest", 86400, false),
-                ("PermissionDenied", 5, true),
                 ("Stop", 5, true),
                 ("SubagentStart", 5, true),
                 ("SubagentStop", 5, true),


### PR DESCRIPTION
## Summary

- Remove PermissionDenied from Claude Code hook events — it is not a recognized hook event in Claude Code's settings schema

## Issue

fix https://github.com/wxtsky/CodeIsland/issues/15