### PR TITLE
fix(hook-server): 修复 bridge half-close 导致权限请求被自动拒绝

### DIFF
--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -142,19 +142,50 @@ class HookServer {
         }
     }
 
-    /// Watch for bridge process disconnect — indicates user answered in terminal
+    /// Per-connection state used by the disconnect monitor.
+    /// `responded` flips to true once we've sent the response, so our own
+    /// `connection.cancel()` inside `sendResponse` does not masquerade as a
+    /// peer disconnect.
+    private final class ConnectionContext {
+        var responded: Bool = false
+    }
+
+    private var connectionContexts: [ObjectIdentifier: ConnectionContext] = [:]
+
+    /// Watch for bridge process disconnect — indicates the bridge process actually died
+    /// (e.g. user Ctrl-C'd Claude Code), NOT a normal half-close.
+    ///
+    /// Previously this used `connection.receive(min:1, max:1)` which triggered on EOF.
+    /// But the bridge always does `shutdown(SHUT_WR)` after sending the request (see
+    /// CodeIslandBridge/main.swift), which produces an immediate EOF on the read side.
+    /// That caused every PermissionRequest to be auto-drained as `deny` before the UI
+    /// card was even visible. We now rely on `stateUpdateHandler` transitioning to
+    /// `cancelled`/`failed` — which only happens on real socket teardown, not half-close.
     private func monitorPeerDisconnect(connection: NWConnection, sessionId: String) {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 1) { [weak self] _, _, isComplete, error in
+        let context = ConnectionContext()
+        connectionContexts[ObjectIdentifier(connection)] = context
+
+        connection.stateUpdateHandler = { [weak self] state in
             Task { @MainActor in
                 guard let self = self else { return }
-                if isComplete || error != nil {
-                    self.appState.handlePeerDisconnect(sessionId: sessionId)
+                switch state {
+                case .cancelled, .failed:
+                    if !context.responded {
+                        self.appState.handlePeerDisconnect(sessionId: sessionId)
+                    }
+                    self.connectionContexts.removeValue(forKey: ObjectIdentifier(connection))
+                default:
+                    break
                 }
             }
         }
     }
 
     private func sendResponse(connection: NWConnection, data: Data) {
+        // Mark as responded BEFORE cancel() so the disconnect monitor ignores our own teardown.
+        if let context = connectionContexts[ObjectIdentifier(connection)] {
+            context.responded = true
+        }
         connection.send(content: data, completion: .contentProcessed { _ in
             connection.cancel()
         })


### PR DESCRIPTION
# fix: avoid auto-deny on PermissionRequest caused by bridge half-close / 修复 bridge half-close 导致权限请求被自动拒绝

## Summary / 变更摘要

### English
- `HookServer.monitorPeerDisconnect` previously used `connection.receive` EOF to detect bridge death, but the bridge always does `shutdown(SHUT_WR)` after sending. The EOF was misinterpreted as peer death, causing **every** `PermissionRequest` to be drained with `deny` before the UI card could even show.
- Replaced the watchdog with `connection.stateUpdateHandler`, which only fires `.cancelled` / `.failed` on real socket teardown — not on half-close.
- Added a per-connection `ConnectionContext.responded` flag so our own `cancel()` inside `sendResponse` doesn't masquerade as a peer disconnect.
- Ctrl-C / real bridge death still triggers `handlePeerDisconnect` correctly — the watchdog's original intent is preserved.

### 中文
- `HookServer.monitorPeerDisconnect` 原来用 `connection.receive` 的 EOF 检测 bridge 死亡，但 bridge 每次发完请求都会 `shutdown(SHUT_WR)`，产生的 EOF 被误判为对端死亡，导致**每一次** `PermissionRequest` 都会在 UI 卡片弹出前被 drain 成 deny。
- 改用 `connection.stateUpdateHandler` 监听 `.cancelled` / `.failed`，只有真正的 socket teardown 才触发，`shutdown(SHUT_WR)` 的 half-close 不会触发。
- 新增 `ConnectionContext.responded` 标志，避免 `sendResponse` 内部自己调 `cancel()` 时被误判为对端断开。
- 保留原语义：bridge 进程真正死亡（如 Ctrl-C）时 `handlePeerDisconnect` 仍能正常触发。

## Screenshots / 示意图

### Before / 修复前

用户看到 `Permission denied by hook`，灵动岛 UI 卡片从未出现，无法手动决策：

<img width="1734" height="138" alt="permission-denied" src="https://github.com/user-attachments/assets/26183632-2080-4055-9f5a-58d1332be91c" />


### After / 修复后

权限卡片正常弹出，等待用户点击 允许 / 拒绝：

<img width="1172" height="310" alt="permission-query-ui" src="https://github.com/user-attachments/assets/3f36650c-2c76-4339-9c75-6686293a35c9" />

Claude Code 端正常等待权限响应：

<img width="1034" height="320" alt="permission-query-terminal" src="https://github.com/user-attachments/assets/bae45336-d657-45d2-9bce-3eaff991b065" />

## Test Plan / 测试说明

- [x] `swift build`
- [x] Reproduce on `main`: `nc -U /tmp/codeisland-$(id -u).sock` with a fake `PermissionRequest` → instant deny, no UI card / 在 `main` 复现：`nc` 瞬间收到 deny，无 UI
- [x] Verify on fix branch: same `nc` command hangs, CodeIsland UI card appears, user can approve/deny / 修复分支：同一命令 hang 住，UI 卡片弹出，可正常决策
- [x] End-to-end with real Claude Code tool call (`Write`) — approval card appears, click `允许一次` proceeds / 真实 Claude Code 工具调用端到端验证通过
