### PR TITLE
fix: start HookServer before installing hooks to prevent startup race

### DIFF
--- a/Sources/CodeIsland/AppDelegate.swift
+++ b/Sources/CodeIsland/AppDelegate.swift
@@ -18,14 +18,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ProcessInfo.processInfo.disableSuddenTermination()
         // Pre-set app icon so Dock/menu bar use the packaged bundle icon.
         NSApp.applicationIconImage = SettingsWindowController.bundleAppIcon()
+        // Start HookServer BEFORE installing hooks into CLI configs.
+        // If we write settings.json first, Claude Code picks up the new hooks
+        // immediately but the socket isn't listening yet — PermissionRequest
+        // hooks get no response and Claude Code denies them.
+        hookServer = HookServer(appState: appState)
+        hookServer?.start()
+
         if ConfigInstaller.install() {
             Self.log.info("Hooks installed")
         } else {
             Self.log.warning("Failed to install hooks")
         }
-
-        hookServer = HookServer(appState: appState)
-        hookServer?.start()
 
         panelController = PanelWindowController(appState: appState)
         panelController?.showPanel()


### PR DESCRIPTION
## Problem

When CodeIsland launches, `git add`, `git commit` and other operations fail with:

```
Error: Permission denied by hook
Denied by PermissionRequest hook
```

This only happens during the first few seconds after CodeIsland starts. Retrying the same operation works fine.

## Root Cause

In `AppDelegate.applicationDidFinishLaunching`, the startup order is:

```swift
// 1. Write hooks to settings.json — Claude Code picks them up IMMEDIATELY
ConfigInstaller.install()

// 2. Start socket server — but Claude Code is already calling hooks!
hookServer = HookServer(appState: appState)
hookServer?.start()
```

Claude Code detects the settings.json change and starts calling hooks right away. But the Unix socket isn't listening yet, so the bridge binary connects to a stale socket (or no socket) and returns no response. For `PermissionRequest` hooks (synchronous, blocking), no response means Claude Code defaults to **deny**.

## Fix

Swap the order — start HookServer first, then write configs:

```swift
// 1. Start socket server FIRST
hookServer = HookServer(appState: appState)
hookServer?.start()

// 2. NOW safe to write hooks — socket is ready for connections
ConfigInstaller.install()
```

## Impact

- One file changed, 7 insertions, 3 deletions
- No behavior change after startup — only the initialization order is affected
- HookServer has no dependency on ConfigInstaller, so reordering is safe

---
Generated with [Claude Code](https://claude.com/claude-code)