### PR TITLE
允许水平拖动

### DIFF
--- a/Sources/CodeIsland/L10n.swift
+++ b/Sources/CodeIsland/L10n.swift
@@ -47,6 +47,8 @@ final class L10n: ObservableObject {
 
         // General
         "launch_at_login": "Launch at Login",
+        "allow_horizontal_drag": "Allow Horizontal Drag",
+        "allow_horizontal_drag_desc": "Enable dragging the panel left or right along the menu bar",
         "display": "Display",
         "auto": "Auto",
         "builtin_display": "Built-in Display",
@@ -212,6 +214,8 @@ final class L10n: ObservableObject {
 
         // General
         "launch_at_login": "登录时打开",
+        "allow_horizontal_drag": "允许水平拖动面板",
+        "allow_horizontal_drag_desc": "开启后可沿菜单栏左右拖动面板位置",
         "display": "显示器",
         "auto": "自动",
         "builtin_display": "内建显示器",

--- a/Sources/CodeIsland/PanelWindowController.swift
+++ b/Sources/CodeIsland/PanelWindowController.swift
@@ -82,7 +82,7 @@ struct PanelScreenHopMotion {
 }
 
 @MainActor
-class PanelWindowController {
+class PanelWindowController: NSObject, NSWindowDelegate {
     private enum ScreenHopMetrics {
         static let outgoingOffset: CGFloat = 18
         static let incomingOffset: CGFloat = 30
@@ -137,9 +137,11 @@ class PanelWindowController {
     private var globalClickMonitor: Any?
     private var lastChosenScreenSignature = ""
     private var isAnimatingScreenHop = false
+    private var isAdjustingDragFrame = false
 
     init(appState: AppState) {
         self.appState = appState
+        super.init()
     }
 
     func showPanel() {
@@ -160,11 +162,12 @@ class PanelWindowController {
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hasShadow = false
-        panel.isMovableByWindowBackground = false
+        panel.isMovableByWindowBackground = SettingsManager.shared.allowHorizontalDrag
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
         panel.sharingType = .readOnly
         panel.contentView = contentView
+        panel.delegate = self
 
         self.panel = panel
         self.lastChosenScreenSignature = ScreenDetector.signature(for: screen)
@@ -386,6 +389,7 @@ class PanelWindowController {
                     self.configureAutoScreenPolling()
                 } else {
                     self.updateVisibility()
+                    self.applyDragModeSetting()
                     self.updatePosition()
                 }
             }
@@ -415,9 +419,25 @@ class PanelWindowController {
     private func panelFrame(for screen: NSScreen) -> NSRect {
         let size = panelSize(for: screen)
         let screenFrame = screen.frame
-        let x = screenFrame.midX - size.width / 2
+        let centeredX = centeredX(for: size, screen: screen)
+        let dragOffset = SettingsManager.shared.allowHorizontalDrag
+            ? CGFloat(SettingsManager.shared.panelHorizontalOffset)
+            : 0
+        let x = clampedX(centeredX + dragOffset, panelWidth: size.width, on: screen)
         let y = screenFrame.maxY - size.height
         return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+    private func centeredX(for size: NSSize, screen: NSScreen) -> CGFloat {
+        screen.frame.midX - size.width / 2
+    }
+
+    private func clampedX(_ desiredX: CGFloat, panelWidth: CGFloat, on screen: NSScreen) -> CGFloat {
+        min(max(desiredX, screen.frame.minX), screen.frame.maxX - panelWidth)
+    }
+
+    private func applyDragModeSetting() {
+        panel?.isMovableByWindowBackground = SettingsManager.shared.allowHorizontalDrag
     }
 
     /// Choose which screen to display on based on displayChoice setting
@@ -509,6 +529,27 @@ class PanelWindowController {
               let session = appState.sessions[sessionId],
               session.termApp != nil else { return false }
         return TerminalVisibilityDetector.isTerminalFrontmostForSession(session)
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        guard let panel, notification.object as AnyObject === panel else { return }
+        guard SettingsManager.shared.allowHorizontalDrag else { return }
+        guard !isAdjustingDragFrame else { return }
+
+        let screen = chosenScreen()
+        let size = panel.frame.size
+        let fixedY = screen.frame.maxY - size.height
+        let clamped = clampedX(panel.frame.origin.x, panelWidth: size.width, on: screen)
+        let corrected = NSRect(x: clamped, y: fixedY, width: size.width, height: size.height)
+
+        if corrected.origin != panel.frame.origin {
+            isAdjustingDragFrame = true
+            panel.setFrame(corrected, display: true)
+            isAdjustingDragFrame = false
+        }
+
+        let offset = clamped - centeredX(for: size, screen: screen)
+        SettingsManager.shared.panelHorizontalOffset = Double(offset)
     }
 
     deinit {

--- a/Sources/CodeIsland/Settings.swift
+++ b/Sources/CodeIsland/Settings.swift
@@ -8,6 +8,8 @@ enum SettingsKey {
     // General - System
     static let launchAtLogin = "launchAtLogin"
     static let displayChoice = "displayChoice"             // "auto", "builtin", "main"
+    static let allowHorizontalDrag = "allowHorizontalDrag"
+    static let panelHorizontalOffset = "panelHorizontalOffset"
 
     // General - Behavior
     static let hideInFullscreen = "hideInFullscreen"
@@ -51,6 +53,8 @@ enum SettingsKey {
 
 struct SettingsDefaults {
     static let displayChoice = "auto"
+    static let allowHorizontalDrag = false
+    static let panelHorizontalOffset = 0.0
     static let hideInFullscreen = true
     static let hideWhenNoSession = false
     static let smartSuppress = true
@@ -88,6 +92,8 @@ class SettingsManager {
     private init() {
         defaults.register(defaults: [
             SettingsKey.displayChoice: SettingsDefaults.displayChoice,
+            SettingsKey.allowHorizontalDrag: SettingsDefaults.allowHorizontalDrag,
+            SettingsKey.panelHorizontalOffset: SettingsDefaults.panelHorizontalOffset,
             SettingsKey.hideInFullscreen: SettingsDefaults.hideInFullscreen,
             SettingsKey.hideWhenNoSession: SettingsDefaults.hideWhenNoSession,
             SettingsKey.smartSuppress: SettingsDefaults.smartSuppress,
@@ -127,6 +133,16 @@ class SettingsManager {
     var displayChoice: String {
         get { defaults.string(forKey: SettingsKey.displayChoice) ?? SettingsDefaults.displayChoice }
         set { defaults.set(newValue, forKey: SettingsKey.displayChoice) }
+    }
+
+    var allowHorizontalDrag: Bool {
+        get { defaults.bool(forKey: SettingsKey.allowHorizontalDrag) }
+        set { defaults.set(newValue, forKey: SettingsKey.allowHorizontalDrag) }
+    }
+
+    var panelHorizontalOffset: Double {
+        get { defaults.double(forKey: SettingsKey.panelHorizontalOffset) }
+        set { defaults.set(newValue, forKey: SettingsKey.panelHorizontalOffset) }
     }
 
     var hideInFullscreen: Bool {

--- a/Sources/CodeIsland/SettingsView.swift
+++ b/Sources/CodeIsland/SettingsView.swift
@@ -127,6 +127,7 @@ private struct SidebarRow: View {
 private struct GeneralPage: View {
     @ObservedObject private var l10n = L10n.shared
     @AppStorage(SettingsKey.displayChoice) private var displayChoice = SettingsDefaults.displayChoice
+    @AppStorage(SettingsKey.allowHorizontalDrag) private var allowHorizontalDrag = SettingsDefaults.allowHorizontalDrag
     @State private var launchAtLogin: Bool
 
     init() {
@@ -145,6 +146,10 @@ private struct GeneralPage: View {
                     .onChange(of: launchAtLogin) { _, v in
                         SettingsManager.shared.launchAtLogin = v
                     }
+                Toggle(l10n["allow_horizontal_drag"], isOn: $allowHorizontalDrag)
+                Text(l10n["allow_horizontal_drag_desc"])
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 Picker(l10n["display"], selection: $displayChoice) {
                     Text(l10n["auto"]).tag("auto")
                     ForEach(Array(NSScreen.screens.enumerated()), id: \.offset) { index, screen in
@@ -1184,4 +1189,3 @@ private struct ShortcutRow: View {
         .contentShape(Rectangle())
     }
 }
-


### PR DESCRIPTION
目前项目启动后出现的窗口固定在刘海屏的位置，像我这种mac m1的电脑没有刘海屏也固定在这里遮住了后面的菜单栏，我希望能够左右拖动它，避免影响我点击后面的状态栏
基于我的需求需要简单实现了下：
1、默认仍然固定在顶部中间（不影响现有用户）。
2、在“设置 -> 通用”新增了开关，默认关闭。
3、打开后可左右拖动面板，纵向位置会被锁定（不会挡住菜单栏上下漂移）。
4、拖动后的水平位置会记住（再次启动后仍生效）。