### PR TITLE
feat(terminal): add cmux surface-level precise jump

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -88,6 +88,16 @@ struct TerminalActivator {
             ? (session.tmuxClientTty ?? session.ttyPath)
             : session.ttyPath
 
+        // --- cmux: surface-level precise jump (workspace + surface) ---
+        // Must be handled before generic tab-switching logic to avoid degrading to bringToFront
+        if lower.contains("cmux") {
+            activateCmux(
+                surfaceId: session.cmuxSurfaceId,
+                workspaceId: session.cmuxWorkspaceId
+            )
+            return
+        }
+
         // --- Tab-level switching (5 terminals) ---
 
         if lower.contains("iterm") {
@@ -596,8 +606,9 @@ struct TerminalActivator {
     }
 
     /// Find a CLI binary in common paths (Homebrew Intel + Apple Silicon, system)
-    private static func findBinary(_ name: String) -> String? {
-        let paths = [
+    /// Support extraPaths for priority search (e.g. app-bundled binaries like cmux)
+    private static func findBinary(_ name: String, extraPaths: [String] = []) -> String? {
+        let paths = extraPaths + [
             "/opt/homebrew/bin/\(name)",
             "/usr/local/bin/\(name)",
             "/usr/bin/\(name)",
@@ -634,5 +645,35 @@ struct TerminalActivator {
         guard let tmuxEnv = tmuxEnv?.trimmingCharacters(in: .whitespacesAndNewlines),
               !tmuxEnv.isEmpty else { return nil }
         return ["TMUX": tmuxEnv]
+    }
+
+    // MARK: - cmux (CLI: focus-panel cross-workspace surface jump)
+
+    /// Activate cmux and precisely focus on the specified surface.
+    /// Prefers surface UUID (CMUX_SURFACE_ID); optionally pass workspace UUID to narrow scope.
+    /// - Parameters:
+    ///   - surfaceId: cmux surface UUID string (from CMUX_SURFACE_ID env var)
+    ///   - workspaceId: cmux workspace UUID string (from CMUX_WORKSPACE_ID env var, optional)
+    private static func activateCmux(surfaceId: String?, workspaceId: String?) {
+        // Reuse activateByBundleId: unified handling of Space switching, hidden state, app not running, etc.
+        activateByBundleId("com.cmuxterm.app")
+
+        // No surface ID — degrade to app-level activation (already done above)
+        guard let sid = surfaceId, !sid.isEmpty else { return }
+
+        // Prefer bundle-embedded binary, then fall back to Homebrew / system paths
+        guard let cmuxBin = findBinary("cmux", extraPaths: [
+            "/Applications/cmux.app/Contents/Resources/bin/cmux",
+            NSHomeDirectory() + "/Applications/cmux.app/Contents/Resources/bin/cmux",
+        ]) else { return }
+
+        // Invoke focus-panel CLI asynchronously to avoid blocking the main thread
+        DispatchQueue.global(qos: .userInitiated).async {
+            var args = ["focus-panel", "--panel", sid]
+            if let wid = workspaceId, !wid.isEmpty {
+                args += ["--workspace", wid]
+            }
+            _ = runProcess(cmuxBin, args: args)
+        }
     }
 }

--- a/Sources/CodeIslandBridge/main.swift
+++ b/Sources/CodeIslandBridge/main.swift
@@ -289,6 +289,16 @@ if !tty.isEmpty {
     json["_tty"] = tty
 }
 
+// cmux surface / workspace (env vars injected by cmux)
+// cmux auto-injects CMUX_SURFACE_ID and CMUX_WORKSPACE_ID into each terminal on launch
+// Bridge simply carries them into the payload during env collection; no extra process calls needed
+if let cmuxSurface = env["CMUX_SURFACE_ID"], !cmuxSurface.isEmpty {
+    json["_cmux_surface_id"] = cmuxSurface
+}
+if let cmuxWorkspace = env["CMUX_WORKSPACE_ID"], !cmuxWorkspace.isEmpty {
+    json["_cmux_workspace_id"] = cmuxWorkspace
+}
+
 // Source tag (e.g. "codex" when called via --source codex)
 if let source = sourceTag {
     json["_source"] = source

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -42,6 +42,8 @@ public struct SessionSnapshot {
     public var tmuxClientTty: String?   // tmux client TTY for real terminal detection
     public var tmuxEnv: String?         // raw TMUX env var (socket info for non-default tmux server)
     public var termBundleId: String?    // __CFBundleIdentifier for precise terminal ID
+    public var cmuxSurfaceId: String?   // cmux surface UUID (from CMUX_SURFACE_ID env var)
+    public var cmuxWorkspaceId: String? // cmux workspace UUID (from CMUX_WORKSPACE_ID env var)
     public var cliPid: pid_t?            // CLI process PID (from bridge _ppid)
     public var source: String = "claude" // "claude" or "codex"
     public var interrupted: Bool = false
@@ -507,6 +509,13 @@ public func reduceEvent(
         if let roots = event.rawJSON["workspace_roots"] as? [String], let first = roots.first, !first.isEmpty {
             sessions[sessionId]?.cwd = first
         }
+        // cmux surface / workspace (restore directly from payload on SessionStart to avoid extractMetadata ordering dependency)
+        if let surface = event.rawJSON["_cmux_surface_id"] as? String, !surface.isEmpty {
+            sessions[sessionId]?.cmuxSurfaceId = surface
+        }
+        if let workspace = event.rawJSON["_cmux_workspace_id"] as? String, !workspace.isEmpty {
+            sessions[sessionId]?.cmuxWorkspaceId = workspace
+        }
         effects.append(.tryMonitorSession(sessionId: sessionId))
     case "SessionEnd":
         // Side effect: AppState handles pending permission deny before removal
@@ -632,6 +641,13 @@ public func extractMetadata(into sessions: inout [String: SessionSnapshot], sess
     }
     if let source = SessionSnapshot.normalizedSupportedSource(event.rawJSON["_source"] as? String) {
         sessions[sessionId]?.source = source
+    }
+    // cmux surface / workspace (injected by bridge from CMUX_SURFACE_ID / CMUX_WORKSPACE_ID env vars)
+    if let surface = event.rawJSON["_cmux_surface_id"] as? String, !surface.isEmpty {
+        sessions[sessionId]?.cmuxSurfaceId = surface
+    }
+    if let workspace = event.rawJSON["_cmux_workspace_id"] as? String, !workspace.isEmpty {
+        sessions[sessionId]?.cmuxWorkspaceId = workspace
     }
 }
 


### PR DESCRIPTION
## Summary
- Bridge collects `CMUX_SURFACE_ID` and `CMUX_WORKSPACE_ID` env vars into payload
- `SessionSnapshot` stores cmux surface/workspace IDs and restores them on `SessionStart`
- `TerminalActivator` handles cmux activation with `focus-panel` CLI for cross-workspace surface jump
- `findBinary` now supports `extraPaths` for app-bundled binary discovery (e.g. cmux inside `cmux.app/Contents/Resources/bin/`)

## Test plan
- [ ] Launch cmux terminal and verify `CMUX_SURFACE_ID` / `CMUX_WORKSPACE_ID` are captured in session
- [ ] Click a cmux session card and verify it jumps to the correct surface/workspace
- [ ] Verify fallback to app-level activation when no surface ID is present
- [ ] Verify cmux binary is found from both bundle-embedded path and Homebrew/system paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)