### PR TITLE
docs: fix debug launch command in source build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ git clone https://github.com/wxtsky/CodeIsland.git
 cd CodeIsland
 
 # Development (debug build + launch)
-swift build && open .build/debug/CodeIsland.app
+swift build && ./.build/debug/CodeIsland
 
 # Release (universal binary: Apple Silicon + Intel)
 ./build.sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ git clone https://github.com/wxtsky/CodeIsland.git
 cd CodeIsland
 
 # 开发模式（debug 构建 + 启动）
-swift build && open .build/debug/CodeIsland.app
+swift build && ./.build/debug/CodeIsland
 
 # 发布模式（通用二进制：Apple Silicon + Intel）
 ./build.sh


### PR DESCRIPTION
  This PR fixes incorrect source-build launch instructions in both English and Chinese READMEs.

  swift build for this SwiftPM project produces an executable (.build/debug/CodeIsland), not an
  app bundle (.app).
  The previous command attempted to open a non-existent .app, causing a “file not found” error.

  Changes

  - Updated README.md:
    - swift build && open .build/debug/CodeIsland.app
    - → swift build && ./.build/debug/CodeIsland
  - Updated README.zh-CN.md with the same fix.

  Why

  To ensure “build from source” instructions actually work in debug/development mode and avoid
  user confusion.

  Test Plan

  - Run swift build successfully
  - Launch with ./.build/debug/CodeIsland
  - Confirm .build/debug/CodeIsland.app does not exist in SwiftPM debug output
  - Verify both README language versions are consistent