### PR TITLE
feat: AskUserQuestion multi-question, multi-select & Other option

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -893,17 +893,26 @@ final class AppState {
         tryMonitorSession(sessionId)
 
         let payload: QuestionPayload
-        if let questions = event.toolInput?["questions"] as? [[String: Any]],
-           let first = questions.first {
-            let questionText = first["question"] as? String ?? "Question"
-            let header = first["header"] as? String
-            var optionLabels: [String]?
-            var optionDescs: [String]?
-            if let opts = first["options"] as? [[String: Any]] {
-                optionLabels = opts.compactMap { $0["label"] as? String }
-                optionDescs = opts.compactMap { $0["description"] as? String }
+        var allItems: [AskUserQuestionItem] = []
+        if let questions = event.toolInput?["questions"] as? [[String: Any]] {
+            for q in questions {
+                let qText = q["question"] as? String ?? "Question"
+                let qHeader = q["header"] as? String
+                let qMultiSelect = q["multiSelect"] as? Bool ?? false
+                var qLabels: [String]?
+                var qDescs: [String]?
+                if let opts = q["options"] as? [[String: Any]] {
+                    qLabels = opts.compactMap { $0["label"] as? String }
+                    qDescs = opts.compactMap { $0["description"] as? String }
+                }
+                allItems.append(AskUserQuestionItem(
+                    question: qText, header: qHeader,
+                    options: qLabels, descriptions: qDescs,
+                    multiSelect: qMultiSelect
+                ))
             }
-            payload = QuestionPayload(question: questionText, options: optionLabels, descriptions: optionDescs, header: header)
+            let first = allItems.first!
+            payload = QuestionPayload(question: first.question, options: first.options, descriptions: first.descriptions, header: first.header)
         } else {
             let questionText = event.toolInput?["question"] as? String ?? "Question"
             var options: [String]?
@@ -921,7 +930,7 @@ final class AppState {
         sessions[sessionId]?.status = .waitingQuestion
         sessions[sessionId]?.lastActivity = Date()
 
-        let request = QuestionRequest(event: event, question: payload, continuation: continuation, isFromPermission: true)
+        let request = QuestionRequest(event: event, question: payload, continuation: continuation, isFromPermission: true, allQuestions: allItems)
         questionQueue.append(request)
 
         if questionQueue.count == 1 {
@@ -935,18 +944,32 @@ final class AppState {
     }
 
     func answerQuestion(_ answer: String) {
+        answerQuestionMulti([(question: "", answer: answer)])
+    }
+
+    func answerQuestionMulti(_ answers: [(question: String, answer: String)]) {
         guard !questionQueue.isEmpty else { return }
         let pending = questionQueue.removeFirst()
         let responseData: Data
         if pending.isFromPermission {
-            let answerKey = pending.question.header ?? "answer"
+            // Build answers dict: {questionText: answer} for each question
+            var answersDict: [String: String] = [:]
+            if !pending.allQuestions.isEmpty {
+                for a in answers {
+                    answersDict[a.question] = a.answer
+                }
+            } else {
+                let answerKey = pending.question.question
+                let answerVal = answers.first?.answer ?? ""
+                answersDict[answerKey] = answerVal
+            }
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
                         "updatedInput": [
-                            "answers": [answerKey: answer]
+                            "answers": answersDict
                         ]
                     ] as [String: Any]
                 ] as [String: Any]
@@ -956,7 +979,7 @@ final class AppState {
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "Notification",
-                    "answer": answer
+                    "answer": answers.first?.answer ?? ""
                 ] as [String: Any]
             ]
             responseData = (try? JSONSerialization.data(withJSONObject: obj)) ?? Data("{}".utf8)

--- a/Sources/CodeIsland/L10n.swift
+++ b/Sources/CodeIsland/L10n.swift
@@ -205,6 +205,8 @@ final class L10n: ObservableObject {
         "type_answer": "Type your answer...",
         "skip": "SKIP",
         "submit": "SUBMIT",
+        "back": "BACK",
+        "confirm": "CONFIRM",
         "open_path": "Open",
         "copy_session_id": "Copy session ID",
 
@@ -394,6 +396,8 @@ final class L10n: ObservableObject {
         "type_answer": "输入回答…",
         "skip": "跳过",
         "submit": "提交",
+        "back": "返回",
+        "confirm": "确认",
         "open_path": "打开",
         "copy_session_id": "复制会话 ID",
 

--- a/Sources/CodeIsland/Models.swift
+++ b/Sources/CodeIsland/Models.swift
@@ -12,11 +12,14 @@ struct QuestionRequest {
     let continuation: CheckedContinuation<Data, Never>
     /// true when converted from AskUserQuestion PermissionRequest
     let isFromPermission: Bool
+    /// All questions from AskUserQuestion (1-4). Empty for Notification-based questions.
+    let allQuestions: [AskUserQuestionItem]
 
-    init(event: HookEvent, question: QuestionPayload, continuation: CheckedContinuation<Data, Never>, isFromPermission: Bool = false) {
+    init(event: HookEvent, question: QuestionPayload, continuation: CheckedContinuation<Data, Never>, isFromPermission: Bool = false, allQuestions: [AskUserQuestionItem] = []) {
         self.event = event
         self.question = question
         self.continuation = continuation
         self.isFromPermission = isFromPermission
+        self.allQuestions = allQuestions
     }
 }

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -121,7 +121,9 @@ struct NotchPanelView: View {
                                 sessionContext: session?.cwd,
                                 queuePosition: 1,
                                 queueTotal: appState.questionQueue.count,
+                                allQuestions: q.allQuestions,
                                 onAnswer: { appState.answerQuestion($0) },
+                                onAnswerMulti: { appState.answerQuestionMulti($0) },
                                 onSkip: { appState.skipQuestion() }
                             )
                             .transition(.blurFade.combined(with: .scale(scale: 0.96, anchor: .top)))
@@ -134,7 +136,9 @@ struct NotchPanelView: View {
                                 sessionContext: session?.cwd,
                                 queuePosition: 1,
                                 queueTotal: 1,
+                                allQuestions: [],
                                 onAnswer: { _ in },
+                                onAnswerMulti: { _ in },
                                 onSkip: { }
                             )
                             .transition(.blurFade.combined(with: .scale(scale: 0.96, anchor: .top)))
@@ -854,14 +858,33 @@ private struct QuestionBar: View {
     let sessionContext: String?
     let queuePosition: Int
     let queueTotal: Int
+    /// All AskUserQuestion items (1-4). Empty for legacy Notification questions.
+    let allQuestions: [AskUserQuestionItem]
     let onAnswer: (String) -> Void
+    let onAnswerMulti: ([(question: String, answer: String)]) -> Void
     let onSkip: () -> Void
 
     @State private var textInput = ""
     @FocusState private var isFocused: Bool
     @State private var selectedIndex: Int? = nil
 
+    // Multi-question state
+    @State private var currentQuestionIndex: Int = 0
+    @State private var collectedAnswers: [(question: String, answer: String)] = []
+    // Multi-select state
+    @State private var selectedIndices: Set<Int> = []
+    // "Other" custom input state
+    @State private var showOtherInput: Bool = false
+    @State private var otherText: String = ""
+    @FocusState private var otherFocused: Bool
+
     private let cyan = Color(red: 0.4, green: 0.7, blue: 1.0)
+
+    private var isMultiQuestion: Bool { allQuestions.count > 1 }
+    private var currentItem: AskUserQuestionItem? {
+        guard !allQuestions.isEmpty, currentQuestionIndex < allQuestions.count else { return nil }
+        return allQuestions[currentQuestionIndex]
+    }
 
     var body: some View {
         VStack(spacing: 8) {
@@ -886,89 +909,385 @@ private struct QuestionBar: View {
                 .padding(.horizontal, 14)
             }
 
-            // Header
-            HStack(spacing: 6) {
-                Text("?")
-                    .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    .foregroundStyle(cyan)
-                Text(question)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.9))
-                    .lineLimit(3)
-                if queueTotal > 1 {
-                    Text("\(queuePosition)/\(queueTotal)")
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .foregroundStyle(.white.opacity(0.5))
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(Color.white.opacity(0.1))
-                        .clipShape(RoundedRectangle(cornerRadius: 3))
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 14)
-
-            // Options
-            if let options = options, !options.isEmpty {
-                VStack(spacing: 4) {
-                    ForEach(Array(options.enumerated()), id: \.offset) { idx, option in
-                        let desc = descriptions?.indices.contains(idx) == true ? descriptions?[idx] : nil
-                        OptionRow(index: idx + 1, label: option, description: desc, isSelected: selectedIndex == idx, accent: cyan) {
-                            selectedIndex = idx
-                            onAnswer(option)
-                        }
-                    }
-                }
-                .padding(.horizontal, 14)
+            if let item = currentItem {
+                multiQuestionContent(item)
             } else {
-                // Text input
-                HStack(spacing: 6) {
-                    Text(">")
-                        .font(.system(size: 10, weight: .bold, design: .monospaced))
-                        .foregroundStyle(Color(red: 0.3, green: 0.85, blue: 0.4))
-                    TextField(L10n.shared["type_answer"], text: $textInput)
-                        .textFieldStyle(.plain)
-                        .font(.system(size: 10.5, design: .monospaced))
-                        .foregroundStyle(.white)
-                        .focused($isFocused)
-                        .onSubmit {
-                            if !textInput.isEmpty { onAnswer(textInput) }
-                        }
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(Color.white.opacity(0.05))
-                .cornerRadius(4)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
-                )
-                .padding(.horizontal, 14)
+                legacyQuestionContent
             }
-
-            // Skip button
-            HStack(spacing: 6) {
-                PixelButton(
-                    label: L10n.shared["skip"],
-                    fg: .white.opacity(0.6),
-                    bg: Color.white.opacity(0.06),
-                    border: Color.white.opacity(0.12),
-                    action: onSkip
-                )
-                if options == nil || options?.isEmpty == true {
-                    PixelButton(
-                        label: L10n.shared["submit"],
-                        fg: .white.opacity(0.95),
-                        bg: Color(red: 0.16, green: 0.38, blue: 0.18),
-                        border: Color(red: 0.28, green: 0.62, blue: 0.32),
-                        action: { if !textInput.isEmpty { onAnswer(textInput) } }
-                    )
-                }
-            }
-            .padding(.horizontal, 14)
         }
         .padding(.vertical, 10)
         .onAppear { isFocused = true }
+    }
+
+    // MARK: - Multi-question content (AskUserQuestion)
+
+    @ViewBuilder
+    private func multiQuestionContent(_ item: AskUserQuestionItem) -> some View {
+        // Header with progress
+        HStack(spacing: 6) {
+            Text("?")
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundStyle(cyan)
+            if let header = item.header, !header.isEmpty {
+                Text(header)
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(cyan.opacity(0.7))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(cyan.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            Text(item.question)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(3)
+            Spacer()
+            if allQuestions.count > 1 {
+                Text("\(currentQuestionIndex + 1)/\(allQuestions.count)")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.5))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(Color.white.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            if queueTotal > 1 {
+                Text("\(queuePosition)/\(queueTotal)")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.4))
+            }
+        }
+        .padding(.horizontal, 14)
+
+        // Options
+        if let opts = item.options, !opts.isEmpty {
+            VStack(spacing: 4) {
+                ForEach(Array(opts.enumerated()), id: \.offset) { idx, option in
+                    let desc = item.descriptions?.indices.contains(idx) == true ? item.descriptions?[idx] : nil
+                    if item.multiSelect {
+                        MultiSelectRow(index: idx + 1, label: option, description: desc,
+                                       isChecked: selectedIndices.contains(idx), accent: cyan) {
+                            if selectedIndices.contains(idx) {
+                                selectedIndices.remove(idx)
+                            } else {
+                                selectedIndices.insert(idx)
+                            }
+                        }
+                    } else {
+                        OptionRow(index: idx + 1, label: option, description: desc,
+                                  isSelected: selectedIndex == idx, accent: cyan) {
+                            selectedIndex = idx
+                            showOtherInput = false
+                            advanceWithAnswer(option)
+                        }
+                    }
+                }
+
+                // "Other" option (always present for AskUserQuestion)
+                otherOptionRow(isMultiSelect: item.multiSelect)
+
+                // "Other" text input (shown when Other is selected)
+                if showOtherInput {
+                    HStack(spacing: 6) {
+                        Text(">")
+                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .foregroundStyle(Color(red: 0.3, green: 0.85, blue: 0.4))
+                        TextField(L10n.shared["type_answer"], text: $otherText)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 10.5, design: .monospaced))
+                            .foregroundStyle(.white)
+                            .focused($otherFocused)
+                            .onSubmit {
+                                if !item.multiSelect && !otherText.isEmpty {
+                                    advanceWithAnswer(otherText)
+                                }
+                            }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.white.opacity(0.05))
+                    .cornerRadius(4)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+                    )
+                    .padding(.horizontal, 14)
+                    .onAppear { otherFocused = true }
+                }
+            }
+            .padding(.horizontal, 14)
+        } else {
+            // No options — text input only
+            HStack(spacing: 6) {
+                Text(">")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(Color(red: 0.3, green: 0.85, blue: 0.4))
+                TextField(L10n.shared["type_answer"], text: $textInput)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundStyle(.white)
+                    .focused($isFocused)
+                    .onSubmit {
+                        if !textInput.isEmpty { advanceWithAnswer(textInput) }
+                    }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.white.opacity(0.05))
+            .cornerRadius(4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+            )
+            .padding(.horizontal, 14)
+        }
+
+        // Buttons
+        HStack(spacing: 6) {
+            if currentQuestionIndex > 0 {
+                PixelButton(
+                    label: L10n.shared["back"],
+                    fg: .white.opacity(0.6),
+                    bg: Color.white.opacity(0.06),
+                    border: Color.white.opacity(0.12),
+                    action: goBack
+                )
+            }
+            PixelButton(
+                label: L10n.shared["skip"],
+                fg: .white.opacity(0.6),
+                bg: Color.white.opacity(0.06),
+                border: Color.white.opacity(0.12),
+                action: onSkip
+            )
+            if item.multiSelect {
+                PixelButton(
+                    label: L10n.shared["confirm"],
+                    fg: .white.opacity(0.95),
+                    bg: Color(red: 0.16, green: 0.38, blue: 0.18),
+                    border: Color(red: 0.28, green: 0.62, blue: 0.32),
+                    action: confirmMultiSelect
+                )
+            } else if item.options == nil || item.options?.isEmpty == true {
+                PixelButton(
+                    label: L10n.shared["submit"],
+                    fg: .white.opacity(0.95),
+                    bg: Color(red: 0.16, green: 0.38, blue: 0.18),
+                    border: Color(red: 0.28, green: 0.62, blue: 0.32),
+                    action: { if !textInput.isEmpty { advanceWithAnswer(textInput) } }
+                )
+            } else if showOtherInput && !item.multiSelect {
+                PixelButton(
+                    label: L10n.shared["submit"],
+                    fg: .white.opacity(0.95),
+                    bg: Color(red: 0.16, green: 0.38, blue: 0.18),
+                    border: Color(red: 0.28, green: 0.62, blue: 0.32),
+                    action: { if !otherText.isEmpty { advanceWithAnswer(otherText) } }
+                )
+            }
+        }
+        .padding(.horizontal, 14)
+    }
+
+    // MARK: - "Other" option row
+
+    @ViewBuilder
+    private func otherOptionRow(isMultiSelect: Bool) -> some View {
+        if isMultiSelect {
+            MultiSelectRow(index: -1, label: L10n.shared["other"], description: nil,
+                           isChecked: showOtherInput, accent: cyan) {
+                showOtherInput.toggle()
+                if !showOtherInput { otherText = "" }
+            }
+        } else {
+            OptionRow(index: -1, label: L10n.shared["other"], description: nil,
+                      isSelected: showOtherInput, accent: cyan) {
+                showOtherInput = true
+                selectedIndex = nil
+            }
+        }
+    }
+
+    // MARK: - Navigation
+
+    private func advanceWithAnswer(_ answer: String) {
+        guard let item = currentItem else { return }
+        collectedAnswers.append((question: item.question, answer: answer))
+
+        if currentQuestionIndex + 1 < allQuestions.count {
+            // Move to next question
+            withAnimation(NotchAnimation.micro) {
+                currentQuestionIndex += 1
+                resetQuestionState()
+            }
+        } else {
+            // All done
+            onAnswerMulti(collectedAnswers)
+        }
+    }
+
+    private func confirmMultiSelect() {
+        guard let item = currentItem, let opts = item.options else { return }
+        var parts: [String] = selectedIndices.sorted().compactMap { idx in
+            opts.indices.contains(idx) ? opts[idx] : nil
+        }
+        if showOtherInput && !otherText.isEmpty {
+            parts.append(otherText)
+        }
+        guard !parts.isEmpty else { return }
+        advanceWithAnswer(parts.joined(separator: ", "))
+    }
+
+    private func goBack() {
+        guard currentQuestionIndex > 0 else { return }
+        collectedAnswers.removeLast()
+        withAnimation(NotchAnimation.micro) {
+            currentQuestionIndex -= 1
+            resetQuestionState()
+        }
+    }
+
+    private func resetQuestionState() {
+        selectedIndex = nil
+        selectedIndices = []
+        showOtherInput = false
+        otherText = ""
+        textInput = ""
+    }
+
+    // MARK: - Legacy single-question content (Notification-based)
+
+    @ViewBuilder
+    private var legacyQuestionContent: some View {
+        // Header
+        HStack(spacing: 6) {
+            Text("?")
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundStyle(cyan)
+            Text(question)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(3)
+            if queueTotal > 1 {
+                Text("\(queuePosition)/\(queueTotal)")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.5))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(Color.white.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+
+        // Options
+        if let options = options, !options.isEmpty {
+            VStack(spacing: 4) {
+                ForEach(Array(options.enumerated()), id: \.offset) { idx, option in
+                    let desc = descriptions?.indices.contains(idx) == true ? descriptions?[idx] : nil
+                    OptionRow(index: idx + 1, label: option, description: desc, isSelected: selectedIndex == idx, accent: cyan) {
+                        selectedIndex = idx
+                        onAnswer(option)
+                    }
+                }
+            }
+            .padding(.horizontal, 14)
+        } else {
+            // Text input
+            HStack(spacing: 6) {
+                Text(">")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(Color(red: 0.3, green: 0.85, blue: 0.4))
+                TextField(L10n.shared["type_answer"], text: $textInput)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundStyle(.white)
+                    .focused($isFocused)
+                    .onSubmit {
+                        if !textInput.isEmpty { onAnswer(textInput) }
+                    }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.white.opacity(0.05))
+            .cornerRadius(4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+            )
+            .padding(.horizontal, 14)
+        }
+
+        // Skip button
+        HStack(spacing: 6) {
+            PixelButton(
+                label: L10n.shared["skip"],
+                fg: .white.opacity(0.6),
+                bg: Color.white.opacity(0.06),
+                border: Color.white.opacity(0.12),
+                action: onSkip
+            )
+            if options == nil || options?.isEmpty == true {
+                PixelButton(
+                    label: L10n.shared["submit"],
+                    fg: .white.opacity(0.95),
+                    bg: Color(red: 0.16, green: 0.38, blue: 0.18),
+                    border: Color(red: 0.28, green: 0.62, blue: 0.32),
+                    action: { if !textInput.isEmpty { onAnswer(textInput) } }
+                )
+            }
+        }
+        .padding(.horizontal, 14)
+    }
+}
+
+// MARK: - Multi-Select Row (checkbox style)
+
+private struct MultiSelectRow: View {
+    let index: Int
+    let label: String
+    let description: String?
+    let isChecked: Bool
+    let accent: Color
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                // Checkbox
+                Image(systemName: isChecked ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 11))
+                    .foregroundStyle(isChecked ? accent : .white.opacity(0.4))
+                    .frame(width: 14)
+                // Label + Description
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.system(size: 10.5, weight: hovering || isChecked ? .semibold : .regular, design: .monospaced))
+                        .foregroundStyle(.white.opacity(hovering || isChecked ? 1 : 0.75))
+                    if let description, !description.isEmpty {
+                        Text(description)
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundStyle(.white.opacity(0.45))
+                            .lineLimit(2)
+                    }
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isChecked ? accent.opacity(0.08) : (hovering ? Color.white.opacity(0.08) : Color.white.opacity(0.03)))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(isChecked ? accent.opacity(0.4) : (hovering ? accent.opacity(0.2) : Color.clear), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { h in withAnimation(NotchAnimation.micro) { hovering = h } }
     }
 }
 
@@ -991,10 +1310,16 @@ private struct OptionRow: View {
                     .font(.system(size: 9, weight: .bold, design: .monospaced))
                     .foregroundStyle(accent)
                     .frame(width: 10)
-                // Number
-                Text("\(index).")
-                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(accent.opacity(hovering ? 1 : 0.6))
+                // Number (or ellipsis for "Other")
+                if index > 0 {
+                    Text("\(index).")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(accent.opacity(hovering ? 1 : 0.6))
+                } else {
+                    Text("…")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(accent.opacity(hovering ? 1 : 0.6))
+                }
                 // Label + Description
                 VStack(alignment: .leading, spacing: 2) {
                     Text(label)

--- a/Sources/CodeIslandCore/Models.swift
+++ b/Sources/CodeIslandCore/Models.swift
@@ -135,6 +135,22 @@ public struct ChatMessage: Identifiable {
     }
 }
 
+public struct AskUserQuestionItem {
+    public let question: String
+    public let header: String?
+    public let options: [String]?
+    public let descriptions: [String]?
+    public let multiSelect: Bool
+
+    public init(question: String, header: String?, options: [String]?, descriptions: [String]?, multiSelect: Bool) {
+        self.question = question
+        self.header = header
+        self.options = options
+        self.descriptions = descriptions
+        self.multiSelect = multiSelect
+    }
+}
+
 public struct QuestionPayload {
     public let question: String
     public let options: [String]?


### PR DESCRIPTION
## Summary

- **Multi-question wizard**: AskUserQuestion supports up to 4 questions per invocation. Previously only the first question was rendered — now all questions are presented sequentially with back/forward navigation.
- **Multi-select support**: Questions with `multiSelect: true` render checkbox-style rows (`MultiSelectRow`) instead of single-select radio buttons, with a CONFIRM button to submit.
- **"Other" free-text option**: Every AskUserQuestion now includes an implicit "Other" option at the bottom, allowing users to type a custom answer instead of picking from the predefined options.
- **Backward compatible**: Legacy Notification-based questions (non-AskUserQuestion) render exactly as before via `legacyQuestionContent`.

## Changes

| File | What changed |
|---|---|
| `Sources/CodeIslandCore/Models.swift` | New `AskUserQuestionItem` struct |
| `Sources/CodeIsland/Models.swift` | `QuestionRequest.allQuestions` field |
| `Sources/CodeIsland/AppState.swift` | Parse all questions (not just first), `answerQuestionMulti()` |
| `Sources/CodeIsland/NotchPanelView.swift` | `QuestionBar` refactored into multi/legacy paths, new `MultiSelectRow`, `OptionRow` supports "Other" (index ≤ 0) |
| `Sources/CodeIsland/L10n.swift` | Added `back` / `confirm` keys (EN + ZH) |

## Test plan

- [ ] Trigger AskUserQuestion with 1 question, single-select — should work as before
- [ ] Trigger AskUserQuestion with 2+ questions — should show wizard with back button and progress indicator
- [ ] Trigger AskUserQuestion with `multiSelect: true` — should show checkboxes and CONFIRM button
- [ ] Click "Other" on any question — should show text input, submitting works
- [ ] Legacy Notification-based questions still render correctly
- [ ] Skip button works at any point in the wizard




https://github.com/user-attachments/assets/665714d5-7931-4e5e-85b6-8d96a686b113


