### PR TITLE
Fix release resource bundle lookup for remote installer

### DIFF
--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -40,11 +40,11 @@ enum RemoteInstaller {
     }
 
     private static func remoteHookSource() -> String? {
-        if let url = Bundle.module.url(forResource: "codeisland-remote-hook", withExtension: "py", subdirectory: "Resources"),
+        if let url = Bundle.appModule.url(forResource: "codeisland-remote-hook", withExtension: "py", subdirectory: "Resources"),
            let src = try? String(contentsOf: url) {
             return src
         }
-        if let url = Bundle.module.url(forResource: "codeisland-remote-hook", withExtension: "py"),
+        if let url = Bundle.appModule.url(forResource: "codeisland-remote-hook", withExtension: "py"),
            let src = try? String(contentsOf: url) {
             return src
         }


### PR DESCRIPTION
## Summary
- switch `RemoteInstaller` resource loading from `Bundle.module` to `Bundle.appModule`
- make release app bundles load `codeisland-remote-hook.py` from the packaged resource bundle path
- avoid the launch-time crash caused by failing to resolve the resource bundle in v1.0.18

## Why
The release `.app` package stores the SPM resource bundle under `Contents/Resources`, but `RemoteInstaller` was still using direct `Bundle.module` lookups. In release builds this could resolve the wrong path and trigger a fatal `could not load resource bundle` crash during startup.

## Verification
- built locally with `env SIGN_ID=- ./build.sh`
- launched the built `.app` successfully on macOS
- confirmed the app no longer crashes at startup from the resource bundle lookup path
