### PR TITLE
fix: defer completion card collapse when mouse is inside panel

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -38,6 +38,8 @@ final class AppState {
     private var completionQueue: [String] = []
     /// Mouse must enter the panel before auto-collapse is allowed (prevents instant dismiss)
     var completionHasBeenEntered = false
+    /// Auto-collapse timer fired but mouse is inside panel — defer collapse until mouse leaves
+    var deferCollapseOnMouseLeave = false
     private var processMonitors: [String: (source: DispatchSourceProcess, process: ProcessIdentity)] = [:]
     private var exitingSessions: [String: ProcessIdentity] = [:]
     private var saveTimer: Timer?
@@ -621,6 +623,7 @@ final class AppState {
         activeSessionId = sessionId
         surface = .completionCard(sessionId: sessionId)
         completionHasBeenEntered = false
+        deferCollapseOnMouseLeave = false
 
         autoCollapseTask?.cancel()
         autoCollapseTask = Task { @MainActor in
@@ -633,9 +636,15 @@ final class AppState {
     func cancelCompletionQueue() {
         autoCollapseTask?.cancel()
         completionQueue.removeAll()
+        deferCollapseOnMouseLeave = false
     }
 
     private func showNextCompletionOrCollapse() {
+        // Once the mouse has entered the completion card, defer collapse until it leaves
+        if completionHasBeenEntered {
+            deferCollapseOnMouseLeave = true
+            return
+        }
         // showNextPending handles: interactive items first, then completionQueue, then collapse
         if showNextPending() { return }
         withAnimation(NotchAnimation.close) {

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -219,13 +219,14 @@ struct NotchPanelView: View {
                     // Completion card: mark entered on hover-in, block collapse until entered
                     if hovering {
                         appState.completionHasBeenEntered = true
-                    } else if appState.completionHasBeenEntered {
-                        // Mouse entered then left — allow collapse
+                    } else if appState.completionHasBeenEntered || appState.deferCollapseOnMouseLeave {
+                        // Mouse entered then left — allow collapse (immediate or deferred)
                         hoverTimer?.invalidate()
                         hoverTimer = nil
+                        appState.deferCollapseOnMouseLeave = false
+                        appState.cancelCompletionQueue()
                         withAnimation(NotchAnimation.close) {
                             appState.surface = .collapsed
-                            appState.cancelCompletionQueue()
                         }
                     }
                     return


### PR DESCRIPTION
  Summary

  - 修复完成卡片（completion card）在鼠标仍在面板内时被自动收起的竞态问题
  - 新增 deferCollapseOnMouseLeave 标志，当 5 秒自动折叠定时器触发但鼠标仍在面板内时，延迟收起到鼠标离开时执行
  - 将模型状态变更移出 withAnimation 闭包，确保动画中断时状态仍能正确更新

  Problem

  完成卡片展示后会在 5 秒后自动折叠。如果用户此时正将鼠标悬停在面板上阅读内容，面板会在用户眼皮底下突然消失，体验不佳。

  Solution

  引入延迟折叠机制：

  1. 定时器触发时，若鼠标已进入过完成卡片（completionHasBeenEntered == true），则设置 deferCollapseOnMouseLeave = true 而非立即折叠
  2. 鼠标离开面板时，检查 completionHasBeenEntered || deferCollapseOnMouseLeave，满足任一条件即执行折叠
  3. 模型状态变更（重置标志、取消队列）放在 withAnimation 闭包外部，保证不受动画中断影响

  Test plan
  - 触发一个任务完成，在完成卡片出现后将鼠标移入面板，等待 5 秒以上，确认面板不会自动折叠
  - 鼠标移出面板后，确认面板正常折叠
  - 完成卡片出现后不将鼠标移入面板，确认 5 秒后正常自动折叠
  - 连续多次触发完成事件，确认队列行为正常
  - 在延迟折叠状态下调用 cancelCompletionQueue()，确认标志被正确重置