### PR TITLE
Fix settings close flicker

### DIFF
--- a/Sources/CodeIsland/SettingsWindowController.swift
+++ b/Sources/CodeIsland/SettingsWindowController.swift
@@ -8,6 +8,13 @@ class SettingsWindowController {
 
     private var closeObserver: NSObjectProtocol?
 
+    private func clearCloseObserver() {
+        if let closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+            self.closeObserver = nil
+        }
+    }
+
     func show() {
         // Switch to regular activation policy so the window can receive focus
         NSApp.setActivationPolicy(.regular)
@@ -46,13 +53,20 @@ class SettingsWindowController {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        // Revert to accessory policy when settings window is closed
+        // Revert to accessory policy after close without hiding the entire app.
+        // Hiding here causes the panel to blink even though only the settings
+        // window is being dismissed.
+        clearCloseObserver()
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification, object: window, queue: .main
-        ) { _ in
-            // Hide Dock tile first to avoid flash of default icon during transition
-            NSApp.setActivationPolicy(.accessory)
-            NSApp.hide(nil)
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.window = nil
+                self?.clearCloseObserver()
+                DispatchQueue.main.async {
+                    NSApp.setActivationPolicy(.accessory)
+                }
+            }
         }
 
         self.window = window


### PR DESCRIPTION
## 概要
- 关闭设置窗口时不再隐藏整个 app
- 仅恢复 accessory 激活策略，不再触发整应用级别的 hide
- 关闭时顺手清理 settings 窗口引用和 close observer

## 原因
之前在设置窗口关闭回调里调用了 `NSApp.hide(nil)`，这会把整个 app 一起隐藏，而不只是关闭设置窗口，因此会导致 CodeIsland 面板在关闭设置时闪一下。

## 结果
关闭设置窗口时，主面板不再出现闪烁。
