### PR TITLE
feat: add CodeBuddy remote hook installation support

### DIFF
--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -31,7 +31,7 @@ enum RemoteInstaller {
             return RemoteInstallResult(ok: false, message: "Install failed: \(configure.stderrSummary)")
         }
 
-        let summary = configure.stdoutSummary.isEmpty ? "Claude/Codex remote hooks installed" : configure.stdoutSummary
+        let summary = configure.stdoutSummary.isEmpty ? "Claude/Codex/CodeBuddy remote hooks installed" : configure.stdoutSummary
         return RemoteInstallResult(ok: true, message: summary)
     }
 
@@ -184,7 +184,36 @@ def install_codex():
     ensure_toml_codex_hooks(codex_root / "config.toml")
     return "Codex ok"
 
-parts = [install_claude(), install_codex()]
+def install_codebuddy():
+    codebuddy_root = home / ".codebuddy"
+    if not codebuddy_root.exists() and shutil.which("codebuddy") is None:
+        return "CodeBuddy skipped"
+
+    settings_path = codebuddy_root / "settings.json"
+    data = ensure_json(settings_path)
+    hooks = data.get("hooks") or {}
+    remove_our_hooks(hooks)
+
+    cmd = command_for("codebuddy")
+    without_matcher = [{"hooks": [{"type": "command", "command": cmd, "timeout": 60}]}]
+    with_matcher = [{"matcher": "*", "hooks": [{"type": "command", "command": cmd, "timeout": 60}]}]
+    with_long_timeout = [{"matcher": "*", "hooks": [{"type": "command", "command": cmd, "timeout": 86400}]}]
+    precompact = [
+        {"matcher": "auto", "hooks": [{"type": "command", "command": cmd, "timeout": 60}]},
+        {"matcher": "manual", "hooks": [{"type": "command", "command": cmd, "timeout": 60}]},
+    ]
+    hooks["UserPromptSubmit"] = without_matcher
+    hooks["PermissionRequest"] = with_long_timeout
+    hooks["Notification"] = with_matcher
+    hooks["Stop"] = without_matcher
+    hooks["SessionStart"] = without_matcher
+    hooks["SessionEnd"] = without_matcher
+    hooks["PreCompact"] = precompact
+    data["hooks"] = hooks
+    write_json(settings_path, data)
+    return "CodeBuddy ok"
+
+parts = [install_claude(), install_codex(), install_codebuddy()]
 print(" · ".join(parts))
 """
         return await runSSH(host: host, command: "python3 - <<'PY'\n\(py)\nPY", timeout: 30)

--- a/Sources/CodeIsland/Resources/codeisland-remote-hook.py
+++ b/Sources/CodeIsland/Resources/codeisland-remote-hook.py
@@ -22,8 +22,16 @@ def _claude_jsonl_path(session_id, cwd):
     return path if os.path.exists(path) else None
 
 
-def _scan_claude_jsonl(session_id, cwd):
-    path = _claude_jsonl_path(session_id, cwd)
+def _codebuddy_jsonl_path(session_id, cwd):
+    if not session_id or not cwd:
+        return None
+    home = os.path.expanduser("~")
+    project_dir = cwd.replace("/", "-").replace(".", "-")
+    path = os.path.join(home, ".codebuddy", "projects", project_dir, f"{session_id}.jsonl")
+    return path if os.path.exists(path) else None
+
+
+def _scan_session_jsonl(path):
     if not path:
         return {}
 
@@ -65,6 +73,14 @@ def _scan_claude_jsonl(session_id, cwd):
         "last_user_message": last_user,
         "last_assistant_message": last_assistant,
     }
+
+
+def _scan_claude_jsonl(session_id, cwd):
+    return _scan_session_jsonl(_claude_jsonl_path(session_id, cwd))
+
+
+def _scan_codebuddy_jsonl(session_id, cwd):
+    return _scan_session_jsonl(_codebuddy_jsonl_path(session_id, cwd))
 
 
 def _read_stdin_json():
@@ -148,6 +164,16 @@ def main():
 
     if SOURCE == "claude":
         extras = _scan_claude_jsonl(session_id, cwd)
+        for key, value in extras.items():
+            if value and not payload.get(key):
+                payload[key] = value
+        if event_name == "UserPromptSubmit" and not payload.get("prompt"):
+            prompt = extras.get("last_user_message")
+            if prompt:
+                payload["prompt"] = prompt
+
+    if SOURCE == "codebuddy":
+        extras = _scan_codebuddy_jsonl(session_id, cwd)
         for key, value in extras.items():
             if value and not payload.get(key):
                 payload[key] = value


### PR DESCRIPTION
RemoteInstaller previously only installed hooks for Claude and Codex on remote hosts. This adds install_codebuddy() targeting ~/.codebuddy/settings.json with the same hook events as Claude, and adds dedicated _codebuddy_jsonl_path() and _scan_codebuddy_jsonl() functions in the remote hook script to scan ~/.codebuddy/projects/ for session data when SOURCE=codebuddy.