### PR TITLE
chore: optimize .gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,25 @@
+# Build artifacts
 .build/
+.swiftpm/
+
+# Superpowers artifacts
 .superpowers/
 HANDOFF.md
 docs/superpowers/
-dev.sh
+
+# macOS system files
 .DS_Store
+
+# IDE vscode/cursor
+.vscode/
+.cursor/
+
+# Tmp files
+.log
+.tmp
+
+# Code agents config files
+.agents/
+.claude/
+skills-lock.json
+CLAUDE.md


### PR DESCRIPTION
## Summary
- 扩展 `.gitignore` 规则，补充 Swift/macOS 构建产物忽略项（如 `.swiftpm/`）。
- 新增本地开发环境相关忽略项，包括编辑器配置、临时文件与系统文件（如 `.vscode/`、`.cursor/`、`.tmp`、`.log`、`.DS_Store`）。
- 新增代码代理/工具配置文件忽略项（如 `.agents/`、`.claude/`、`skills-lock.json`、`CLAUDE.md`），避免本地私有配置误提交。

## Why
- 当前忽略规则对本地开发产物覆盖不足，容易将与业务无关的本地文件（构建缓存、IDE 配置、代理配置等）纳入版本控制，增加仓库噪音和误提交风险。

## Changes
- 更新文件：`.gitignore`
- 变更规模：`1 file changed, 20 insertions(+), 1 deletion(-)`

## Impact
- 仅影响 Git 跟踪行为，不涉及运行时逻辑或业务功能变更。
- 有助于保持仓库整洁，降低本地文件误提交概率。