### PR TITLE
feat(panel): add click-to-jump on permission approval card

### DIFF
--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -108,13 +108,17 @@ struct NotchPanelView: View {
                         .padding(.horizontal, 12)
 
                     switch appState.surface {
-                    case .approvalCard:
+                    case .approvalCard(let sid):
                         if let pending = appState.pendingPermission {
+                            let session = appState.sessions[sid]
                             ApprovalBar(
                                 tool: pending.event.toolName ?? "Unknown",
                                 toolInput: pending.event.toolInput,
                                 queuePosition: 1,
                                 queueTotal: appState.permissionQueue.count,
+                                session: session,
+                                sessionId: sid,
+                                appState: appState,
                                 onAllow: { appState.approvePermission(always: false) },
                                 onAlwaysAllow: { appState.approvePermission(always: true) },
                                 onDeny: { appState.denyPermission() },
@@ -827,10 +831,18 @@ private struct ApprovalBar: View {
     let toolInput: [String: Any]?
     let queuePosition: Int
     let queueTotal: Int
+    let session: SessionSnapshot?
+    let sessionId: String
+    let appState: AppState
     let onAllow: () -> Void
     let onAlwaysAllow: () -> Void
     let onDeny: () -> Void
     let onDismiss: () -> Void
+
+    // Jump validation state for click-to-jump functionality
+    @State private var failureShakeOffset: CGFloat = 0
+    @State private var jumpValidationTask: Task<Void, Never>?
+    @AppStorage(SettingsKey.autoCollapseAfterSessionJump) private var autoCollapseAfterSessionJump = SettingsDefaults.autoCollapseAfterSessionJump
 
     private var fileName: String? {
         guard let fp = toolInput?["file_path"] as? String else { return nil }
@@ -877,6 +889,8 @@ private struct ApprovalBar: View {
                 Spacer()
             }
             .padding(.horizontal, 14)
+            .contentShape(Rectangle())
+            .onTapGesture { handleCardClick() }
 
             // Tool-specific detail view
             if toolInput != nil {
@@ -885,6 +899,8 @@ private struct ApprovalBar: View {
                     .padding(.vertical, 6)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.04))
+                    .contentShape(Rectangle())
+                    .onTapGesture { handleCardClick() }
             }
 
             // Pixel-style buttons
@@ -897,8 +913,77 @@ private struct ApprovalBar: View {
             .padding(.horizontal, 14)
         }
         .padding(.vertical, 10)
+        .offset(x: failureShakeOffset)
+        .onDisappear {
+            jumpValidationTask?.cancel()
+            jumpValidationTask = nil
+        }
     }
 
+    // MARK: - Click-to-jump handling
+
+    /// Handle click on approval card to jump to terminal (same as SessionCard behavior)
+    private func handleCardClick() {
+        // Skip for remote sessions
+        guard let session = session, !session.isRemote else { return }
+
+        TerminalActivator.activate(session: session, sessionId: sessionId)
+
+        guard autoCollapseAfterSessionJump else { return }
+
+        jumpValidationTask?.cancel()
+        jumpValidationTask = Task {
+            let delays: [UInt64] = [120_000_000, 320_000_000, 640_000_000]
+            let outcome = await evaluateJumpValidation(
+                delays: delays,
+                checkSucceeded: { await checkJumpSucceeded(session: session) }
+            )
+
+            switch outcome {
+            case .success:
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    switch appState.surface {
+                    case .approvalCard:
+                        withAnimation(NotchAnimation.close) {
+                            appState.surface = .collapsed
+                        }
+                    default:
+                        break
+                    }
+                }
+            case .failed:
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    SoundManager.shared.preview("8bit_error")
+                }
+                guard !Task.isCancelled else { return }
+                await runJumpFailureShakeAnimation()
+            case .cancelled:
+                return
+            }
+        }
+    }
+
+    private func checkJumpSucceeded(session: SessionSnapshot) async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let succeeded = TerminalVisibilityDetector.isSessionTabVisible(session)
+                    || TerminalVisibilityDetector.isTerminalFrontmostForSession(session)
+                continuation.resume(returning: succeeded)
+            }
+        }
+    }
+
+    @MainActor
+    private func runJumpFailureShakeAnimation() async {
+        for offset in jumpFailureShakeSequence() {
+            withAnimation(.easeInOut(duration: 0.035)) {
+                failureShakeOffset = CGFloat(offset)
+            }
+            try? await Task.sleep(nanoseconds: 35_000_000)
+        }
+    }
 }
 
 // MARK: - Question Bar (below notch, auto-expanded)

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -924,8 +924,15 @@ private struct ApprovalBar: View {
 
     /// Handle click on approval card to jump to terminal (same as SessionCard behavior)
     private func handleCardClick() {
+        // If session is nil (removed but card still showing), show failure feedback
+        guard let session = session else {
+            SoundManager.shared.preview("8bit_error")
+            Task { @MainActor in await runJumpFailureShakeAnimation() }
+            return
+        }
+
         // Skip for remote sessions
-        guard let session = session, !session.isRemote else { return }
+        guard !session.isRemote else { return }
 
         TerminalActivator.activate(session: session, sessionId: sessionId)
 

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -991,11 +991,11 @@ private struct ApprovalBar: View {
 
     @MainActor
     private func runJumpFailureShakeAnimation() async {
-        await runSharedJumpFailureShakeAnimation(offset: $failureShakeOffset)
+        await JumpAnimationHelper.runShake(offset: $failureShakeOffset)
     }
 }
 
-// MARK: - Jump Animation Helpers
+// MARK: - Question Bar (below notch, auto-expanded)
 
 private struct QuestionBar: View {
     let question: String
@@ -1807,19 +1807,19 @@ func shouldTriggerJumpFailureFeedback(_ jumpChecks: [Bool]) -> Bool {
     !jumpChecks.contains(true)
 }
 
-func jumpFailureShakeSequence() -> [Int] {
-    [8, -8, 6, -6, 3, -3, 0]
-}
+/// Namespace for jump animation utilities shared between ApprovalBar and SessionCard
+enum JumpAnimationHelper {
+    static let shakeSequence = [8, -8, 6, -6, 3, -3, 0]
+    static let shakeStepDuration: UInt64 = 35_000_000
 
-/// Shake animation helper - sets offset values from jumpFailureShakeSequence() with 35ms delays
-/// - Parameter offset: The binding to animate with shake values
-@MainActor
-private func runSharedJumpFailureShakeAnimation(offset: Binding<CGFloat>) async {
-    for value in jumpFailureShakeSequence() {
-        withAnimation(.easeInOut(duration: 0.035)) {
-            offset.wrappedValue = CGFloat(value)
+    @MainActor
+    static func runShake(offset: Binding<CGFloat>) async {
+        for value in shakeSequence {
+            withAnimation(.easeInOut(duration: 0.035)) {
+                offset.wrappedValue = CGFloat(value)
+            }
+            try? await Task.sleep(nanoseconds: shakeStepDuration)
         }
-        try? await Task.sleep(nanoseconds: 35_000_000)
     }
 }
 
@@ -2174,7 +2174,7 @@ private struct SessionCard: View {
 
     @MainActor
     private func runJumpFailureShakeAnimation() async {
-        await runSharedJumpFailureShakeAnimation(offset: $failureShakeOffset)
+        await JumpAnimationHelper.runShake(offset: $failureShakeOffset)
     }
 
     private func timeAgo(_ date: Date) -> String {

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -922,22 +922,28 @@ private struct ApprovalBar: View {
 
     // MARK: - Click-to-jump handling
 
-    /// Handle click on approval card to jump to terminal (same as SessionCard behavior)
+    /// Handle click on approval card to jump to terminal.
+    /// Logic mirrors SessionCard.handleSessionClick():
+    /// - nil session: play error sound + shake animation
+    /// - remote session: skip (no terminal to jump to)
+    /// - valid local session: activate terminal + optionally auto-collapse
     private func handleCardClick() {
-        // If session is nil (removed but card still showing), show failure feedback
+        // Session may be nil if removed while card is still visible
         guard let session = session else {
             SoundManager.shared.preview("8bit_error")
             Task { @MainActor in await runJumpFailureShakeAnimation() }
             return
         }
 
-        // Skip for remote sessions
+        // Remote sessions have no local terminal
         guard !session.isRemote else { return }
 
         TerminalActivator.activate(session: session, sessionId: sessionId)
 
         guard autoCollapseAfterSessionJump else { return }
 
+        // Validate jump: retry 3x with increasing delays (120ms, 320ms, 640ms)
+        // Collapse on success; play error sound + shake on failure
         jumpValidationTask?.cancel()
         jumpValidationTask = Task {
             let delays: [UInt64] = [120_000_000, 320_000_000, 640_000_000]
@@ -949,6 +955,7 @@ private struct ApprovalBar: View {
             switch outcome {
             case .success:
                 guard !Task.isCancelled else { return }
+                // Auto-collapse to collapsed surface on successful jump
                 await MainActor.run {
                     switch appState.surface {
                     case .approvalCard:
@@ -984,16 +991,11 @@ private struct ApprovalBar: View {
 
     @MainActor
     private func runJumpFailureShakeAnimation() async {
-        for offset in jumpFailureShakeSequence() {
-            withAnimation(.easeInOut(duration: 0.035)) {
-                failureShakeOffset = CGFloat(offset)
-            }
-            try? await Task.sleep(nanoseconds: 35_000_000)
-        }
+        await runSharedJumpFailureShakeAnimation(offset: $failureShakeOffset)
     }
 }
 
-// MARK: - Question Bar (below notch, auto-expanded)
+// MARK: - Jump Animation Helpers
 
 private struct QuestionBar: View {
     let question: String
@@ -1809,6 +1811,18 @@ func jumpFailureShakeSequence() -> [Int] {
     [8, -8, 6, -6, 3, -3, 0]
 }
 
+/// Shake animation helper - sets offset values from jumpFailureShakeSequence() with 35ms delays
+/// - Parameter offset: The binding to animate with shake values
+@MainActor
+private func runSharedJumpFailureShakeAnimation(offset: Binding<CGFloat>) async {
+    for value in jumpFailureShakeSequence() {
+        withAnimation(.easeInOut(duration: 0.035)) {
+            offset.wrappedValue = CGFloat(value)
+        }
+        try? await Task.sleep(nanoseconds: 35_000_000)
+    }
+}
+
 enum JumpValidationOutcome: Equatable {
     case success
     case failed
@@ -2160,12 +2174,7 @@ private struct SessionCard: View {
 
     @MainActor
     private func runJumpFailureShakeAnimation() async {
-        for offset in jumpFailureShakeSequence() {
-            withAnimation(.easeInOut(duration: 0.035)) {
-                failureShakeOffset = CGFloat(offset)
-            }
-            try? await Task.sleep(nanoseconds: 35_000_000)
-        }
+        await runSharedJumpFailureShakeAnimation(offset: $failureShakeOffset)
     }
 
     private func timeAgo(_ date: Date) -> String {

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -930,8 +930,10 @@ private struct ApprovalBar: View {
     private func handleCardClick() {
         // Session may be nil if removed while card is still visible
         guard let session = session else {
-            SoundManager.shared.preview("8bit_error")
-            Task { @MainActor in await runJumpFailureShakeAnimation() }
+            Task { @MainActor in
+                SoundManager.shared.preview("8bit_error")
+                await runJumpFailureShakeAnimation()
+            }
             return
         }
 

--- a/Tests/CodeIslandTests/NotchPanelViewTests.swift
+++ b/Tests/CodeIslandTests/NotchPanelViewTests.swift
@@ -11,7 +11,7 @@ final class NotchPanelViewTests: XCTestCase {
     }
 
     func testJumpFailureShakeSequenceUsesFastAlternatingOffsets() {
-        XCTAssertEqual(jumpFailureShakeSequence(), [8, -8, 6, -6, 3, -3, 0])
+        XCTAssertEqual(JumpAnimationHelper.shakeSequence, [8, -8, 6, -6, 3, -3, 0])
     }
 
     func testEvaluateJumpValidationReturnsSuccessWhenCheckSucceeds() async {


### PR DESCRIPTION
## Summary

- 点击权限审批卡片可跳转到对应终端窗口，与 SessionCard 行为一致
- Session 为 nil 时播放错误音效 + 摇晃动画反馈
- 远程会话静默跳过（无本地终端可跳转）
- 跳转验证成功后可自动收起面板（取决于 autoCollapseAfterSessionJump 设置）
- 提取 `JumpAnimationHelper` 命名空间统一管理动画工具

已在本地测试正常。

## Changes

- `ApprovalBar` 新增 `session`、`sessionId`、`appState` 参数支持跳转功能
- 新增 `handleCardClick()` 复用 `SessionCard.handleSessionClick()` 逻辑
- 统一 nil session 和 validation failed 的错误反馈模式
- 将 `jumpFailureShakeSequence` 和 `runShake` 封装为 `JumpAnimationHelper` enum

## Test plan

- [x] Build succeeds with no new warnings
- [x] All 103 tests pass (including updated `JumpAnimationHelper.shakeSequence` test)
- [ ] Manual: click approval card → terminal window activates
- [ ] Manual: nil session → error sound + shake animation
- [ ] Manual: remote session → silent skip, no crash
- [ ] Manual: Allow/Deny/Dismiss buttons still work correctly