### PR TITLE
fix: 修复 TraeCli YAML hook 注入异常

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
         "version" : "2.9.1"
       }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         // Sparkle — auto-update framework. Pinned to 2.6+ for stable
         // SPUStandardUpdaterController + ed25519 signature verification.
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     ],
     targets: [
         .target(
@@ -19,6 +20,9 @@ let package = Package(
             dependencies: [
                 "CodeIslandCore",
                 .product(name: "Sparkle", package: "Sparkle"),
+                .product(name: "Yams", package: "Yams"),
+                .product(name: "Sparkle", package: "Sparkle"),
+                .product(name: "Yams", package: "Yams"),
             ],
             path: "Sources/CodeIsland",
             resources: [
@@ -37,7 +41,10 @@ let package = Package(
         ),
         .testTarget(
             name: "CodeIslandTests",
-            dependencies: ["CodeIsland"],
+            dependencies: [
+                "CodeIsland",
+                .product(name: "Yams", package: "Yams"),
+            ],
             path: "Tests/CodeIslandTests"
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,6 @@ let package = Package(
                 "CodeIslandCore",
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "Yams", package: "Yams"),
-                .product(name: "Sparkle", package: "Sparkle"),
-                .product(name: "Yams", package: "Yams"),
             ],
             path: "Sources/CodeIsland",
             resources: [

--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CodeIslandCore
+import Yams
 
 // MARK: - Hook Identifiers
 
@@ -965,21 +966,127 @@ struct ConfigInstaller {
         )
     }
 
-    private static func renderManagedTraecliHooks(source: String = "traecli") -> String {
+    private static func managedTraecliHookObject(source: String = "traecli") -> [String: Any] {
         let quotedBridge = bridgeCommand.contains(" ") ? "\"\(bridgeCommand)\"" : bridgeCommand
-        let escapedCommand = "\(quotedBridge) --source \(source)".replacingOccurrences(of: "'", with: "''")
+        let command = "\(quotedBridge) --source \(source)"
 
         let events = defaultEvents(for: .traecli)
         let timeout = events.map { $0.1 }.max() ?? 5
 
-        var lines: [String] = ["  - type: command"]
-        lines.append("    command: '\(escapedCommand)'")
-        lines.append("    timeout: '\(timeout)s'")
-        lines.append("    matchers:")
-        for (event, _, _) in events {
-            lines.append("      - event: \(event)")
+        let matchers: [[String: Any]] = events.map { (event, _, _) in
+            ["event": event]
         }
-        return lines.joined(separator: "\n")
+
+        return [
+            "type": "command",
+            "command": command,
+            "timeout": "\(timeout)s",
+            "matchers": matchers,
+        ]
+    }
+
+    private static func asStringKeyedDict(_ any: Any) -> [String: Any]? {
+        if let d = any as? [String: Any] { return d }
+        if let d = any as? [AnyHashable: Any] {
+            var out: [String: Any] = [:]
+            out.reserveCapacity(d.count)
+            for (k, v) in d {
+                guard let ks = k as? String else { continue }
+                out[ks] = v
+            }
+            return out
+        }
+        return nil
+    }
+
+    /// Best-effort repair for invalid YAML produced by mixed indentation under `hooks:`.
+    ///
+    /// This is only used as a recovery step when YAML parsing fails, to make the file
+    /// parseable so it can be re-serialized via Yams.
+    private static func normalizeTraecliHooksListIndentation(_ contents: String) -> String {
+        let normalized = contents.replacingOccurrences(of: "\r\n", with: "\n")
+        let lines = normalized.components(separatedBy: "\n")
+        guard let hooksIndex = lines.firstIndex(where: { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard line == trimmed else { return false } // top-level only
+            return trimmed.hasPrefix("hooks:")
+        }) else {
+            return normalized
+        }
+
+        // Determine the intended indentation for *hook items* under hooks:
+        // Only consider "- type:" / "- command:" so we don't confuse nested matcher lists.
+        var hookIndent: Int?
+        var i = hooksIndex + 1
+        var indents: [Int] = []
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                i += 1
+                continue
+            }
+            // Stop if we hit another top-level key.
+            if line == trimmed, trimmed.contains(":"), !trimmed.hasPrefix("hooks:") {
+                break
+            }
+            if trimmed.hasPrefix("- type:") || trimmed.hasPrefix("- command:") {
+                indents.append(line.prefix { $0 == " " }.count)
+            }
+            i += 1
+        }
+        hookIndent = indents.min()
+        guard let baseIndent = hookIndent else { return normalized }
+
+        var out = lines
+        i = hooksIndex + 1
+        while i < out.count {
+            let line = out[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                i += 1
+                continue
+            }
+            // Stop when leaving hooks section (top-level key).
+            if line == trimmed, trimmed.contains(":"), !trimmed.hasPrefix("hooks:") {
+                break
+            }
+
+            if (trimmed.hasPrefix("- type:") || trimmed.hasPrefix("- command:")) {
+                let indent = line.prefix { $0 == " " }.count
+                if indent > baseIndent {
+                    let delta = indent - baseIndent
+                    // Shift the whole list item block left by delta spaces.
+                    var j = i
+                    while j < out.count {
+                        let next = out[j]
+                        let nextTrimmed = next.trimmingCharacters(in: .whitespaces)
+                        let nextIndent = next.prefix { $0 == " " }.count
+
+                        if j != i {
+                            // Next item in the same list at the original indent ends the block.
+                            if nextIndent == indent && nextTrimmed.hasPrefix("- ") {
+                                break
+                            }
+                            // Leaving this list item (less indent + non-empty) ends the block.
+                            if nextIndent < indent && !nextTrimmed.isEmpty {
+                                break
+                            }
+                        }
+
+                        if next.hasPrefix(String(repeating: " ", count: delta)) {
+                            out[j] = String(next.dropFirst(delta))
+                        }
+                        j += 1
+                    }
+                    i = j
+                    continue
+                }
+            }
+            i += 1
+        }
+
+        return out.joined(separator: "\n")
     }
 
     private static func isTraecliCommandListItemStart(_ trimmed: String) -> Bool {
@@ -1085,7 +1192,7 @@ struct ConfigInstaller {
         return false
     }
 
-    static func removeManagedTraecliHooks(from contents: String, source: String = "traecli") -> String {
+    private static func removeManagedTraecliHooksLegacy(from contents: String, source: String = "traecli") -> String {
         let normalized = contents.replacingOccurrences(of: "\r\n", with: "\n")
         let lines = normalized.components(separatedBy: "\n")
         var result: [String] = []
@@ -1171,39 +1278,85 @@ struct ConfigInstaller {
         return result.joined(separator: "\n")
     }
 
+    static func removeManagedTraecliHooks(from contents: String, source: String = "traecli") -> String {
+        // Fast path: empty file.
+        if contents.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return contents
+        }
+
+        let normalized = contents.replacingOccurrences(of: "\r\n", with: "\n")
+        let parseInputs = [normalized, normalizeTraecliHooksListIndentation(normalized)]
+        for input in parseInputs {
+            do {
+                guard let loaded = try Yams.load(yaml: input) else { continue }
+                guard var root = asStringKeyedDict(loaded) else { continue }
+                guard let hooksAny = root["hooks"] else { return contents }
+                guard let hooks = hooksAny as? [Any] else { return contents }
+
+                var didRemove = false
+                var cleaned: [Any] = []
+                cleaned.reserveCapacity(hooks.count)
+                for item in hooks {
+                    guard let hook = asStringKeyedDict(item),
+                          let command = hook["command"] as? String,
+                          isOurTraecliInjectedCommand(command, source: source)
+                    else {
+                        cleaned.append(item)
+                        continue
+                    }
+                    didRemove = true
+                }
+
+                guard didRemove else { return contents }
+                root["hooks"] = cleaned
+
+                var dumped = try Yams.dump(object: root)
+                if !dumped.hasSuffix("\n") { dumped.append("\n") }
+                return dumped
+            } catch {
+                continue
+            }
+        }
+
+        // YAML still unparseable — fall back to the legacy remover (best effort).
+        return removeManagedTraecliHooksLegacy(from: contents, source: source)
+    }
+
     static func mergeTraecliHooks(into contents: String, source: String = "traecli") -> String {
-        let cleaned = removeManagedTraecliHooks(from: contents, source: source)
-        let managedLines = renderManagedTraecliHooks(source: source).components(separatedBy: "\n")
-        var lines = cleaned.components(separatedBy: "\n")
+        let normalized = contents.replacingOccurrences(of: "\r\n", with: "\n")
+        let parseInputs = [normalized, normalizeTraecliHooksListIndentation(normalized)]
 
-        // Find a top-level hooks key. Handle common scalar/empty forms like "hooks: []" to
-        // avoid producing invalid YAML by appending block items to a flow sequence.
-        if let hooksIndex = lines.firstIndex(where: { line in
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard line == trimmed else { return false } // top-level only
-            return trimmed.range(of: #"^hooks:\s*(\[\s*\]|\{\s*\}|null|~)?\s*(#.*)?$"#, options: .regularExpression) != nil
-        }) {
-            let trimmed = lines[hooksIndex].trimmingCharacters(in: .whitespaces)
-            if trimmed.range(of: #"^hooks:\s*(\[\s*\]|\{\s*\}|null|~)\s*(#.*)?$"#, options: .regularExpression) != nil {
-                lines[hooksIndex] = "hooks:"
+        for input in parseInputs {
+            do {
+                let loaded = try Yams.load(yaml: input)
+                var root: [String: Any] = loaded.flatMap(asStringKeyedDict) ?? [:]
+
+                let hooksAny = root["hooks"]
+                var hooks: [Any] = []
+                if let existing = hooksAny as? [Any] {
+                    hooks = existing
+                }
+
+                // Remove existing managed hook(s) and then prepend the fresh one.
+                hooks.removeAll { item in
+                    guard let hook = asStringKeyedDict(item),
+                          let command = hook["command"] as? String
+                    else { return false }
+                    return isOurTraecliInjectedCommand(command, source: source)
+                }
+                hooks.insert(managedTraecliHookObject(source: source), at: 0)
+                root["hooks"] = hooks
+
+                var dumped = try Yams.dump(object: root)
+                if !dumped.hasSuffix("\n") { dumped.append("\n") }
+                return dumped
+            } catch {
+                continue
             }
-            lines.insert(contentsOf: managedLines, at: hooksIndex + 1)
-        } else {
-            while !lines.isEmpty && lines.last == "" {
-                lines.removeLast()
-            }
-            if !lines.isEmpty {
-                lines.append("")
-            }
-            lines.append("hooks:")
-            lines.append(contentsOf: managedLines)
         }
 
-        var merged = lines.joined(separator: "\n")
-        if !merged.hasSuffix("\n") {
-            merged.append("\n")
-        }
-        return merged
+        // Still unparseable: last resort, do not clobber user data.
+        return contents.hasSuffix("\n") ? contents : (contents + "\n")
     }
 
     @discardableResult

--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -148,20 +148,125 @@ TRAECLI_EVENTS = [
     ("post_compact", 5),
 ]
 
-def _render_managed_traecli_hooks(cmd):
+def _normalize_traecli_hooks_list_indentation(contents):
+    # Best-effort repair for invalid YAML produced by mixed indentation under top-level `hooks:`.
+    #
+    # Only normalize indentation of *hook items* ("- type:" / "- command:")
+    # and shift the entire list item block left to match the smallest indent.
+    normalized = contents.replace("\\r\\n", "\\n")
+    lines = normalized.split("\\n")
+
+    hooks_index = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if line != stripped:
+            continue
+        if stripped.startswith("hooks:"):
+            hooks_index = i
+            break
+    if hooks_index is None:
+        return normalized
+
+    def _is_top_level_key(line):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            return False
+        if line != stripped:
+            return False
+        return ":" in stripped and not stripped.startswith("hooks:")
+
+    # Find the smallest indent among hook items.
+    indents = []
+    i = hooks_index + 1
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        if _is_top_level_key(line):
+            break
+        if stripped.startswith("- type:") or stripped.startswith("- command:"):
+            indents.append(len(line) - len(line.lstrip(" ")))
+        i += 1
+    if not indents:
+        return normalized
+    base_indent = min(indents)
+
+    out = list(lines)
+    i = hooks_index + 1
+    while i < len(out):
+        line = out[i]
+        stripped = line.strip()
+        if not stripped:
+            i += 1
+            continue
+        if _is_top_level_key(line):
+            break
+        if stripped.startswith("- type:") or stripped.startswith("- command:"):
+            indent = len(line) - len(line.lstrip(" "))
+            if indent > base_indent:
+                delta = indent - base_indent
+                j = i
+                while j < len(out):
+                    nxt = out[j]
+                    nxt_stripped = nxt.strip()
+                    nxt_indent = len(nxt) - len(nxt.lstrip(" "))
+                    if j != i:
+                        if nxt_indent == indent and nxt_stripped.startswith("- "):
+                            break
+                        if nxt_indent < indent and nxt_stripped != "":
+                            break
+                    if nxt.startswith(" " * delta):
+                        out[j] = nxt[delta:]
+                    j += 1
+                i = j
+                continue
+        i += 1
+
+    return "\\n".join(out)
+
+def _detect_traecli_hook_item_indent(lines, hooks_index):
+    def _is_top_level_key(line):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            return False
+        if line != stripped:
+            return False
+        return ":" in stripped and not stripped.startswith("hooks:")
+
+    indents = []
+    i = hooks_index + 1
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        if _is_top_level_key(line):
+            break
+        if stripped.startswith("- type:") or stripped.startswith("- command:"):
+            indents.append(len(line) - len(line.lstrip(" ")))
+        i += 1
+    return min(indents) if indents else 2
+
+def _render_managed_traecli_hooks(cmd, indent=2):
     # Escape single quotes for YAML single-quoted string
     escaped = cmd.replace("'", "''")
     timeout = max([t for (_, t) in TRAECLI_EVENTS] or [5])
-    lines = ["  - type: command"]
-    lines.append(f"    command: '{escaped}'")
-    lines.append(f"    timeout: '{timeout}s'")
-    lines.append("    matchers:")
+    pad = " " * indent
+    pad2 = " " * (indent + 2)
+    pad4 = " " * (indent + 4)
+    lines = [f"{pad}- type: command"]
+    lines.append(f"{pad2}command: '{escaped}'")
+    lines.append(f"{pad2}timeout: '{timeout}s'")
+    lines.append(f"{pad2}matchers:")
     for (event, _) in TRAECLI_EVENTS:
-        lines.append(f"      - event: {event}")
+        lines.append(f"{pad4}- event: {event}")
     return "\\n".join(lines)
 
 def _remove_managed_traecli_hooks(contents):
-    normalized = contents.replace("\\r\\n", "\\n")
+    normalized = _normalize_traecli_hooks_list_indentation(contents)
     lines = normalized.split("\\n")
     result = []
 
@@ -180,7 +285,22 @@ def _remove_managed_traecli_hooks(contents):
         return raw
 
     def _normalize_cmd(cmd):
-        return " ".join((cmd or "").strip().split())
+        s = " ".join((cmd or "").strip().split())
+        if not s:
+            return s
+        # Normalize first token: allow quoted executable path.
+        if s.startswith('"'):
+            end = s.find('"', 1)
+            if end != -1:
+                first = s[1:end]
+                rest = s[end+1:].strip()
+                s = first + (" " + rest if rest else "")
+        parts = s.split(" ", 1)
+        first = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+        if first.startswith("~/"):
+            first = str(home) + "/" + first[2:]
+        return first + (" " + rest if rest else "")
 
     i = 0
     while i < len(lines):
@@ -240,8 +360,8 @@ def _remove_managed_traecli_hooks(contents):
     return "\\n".join(result)
 
 def _merge_traecli_hooks(contents, cmd):
-    cleaned = _remove_managed_traecli_hooks(contents)
-    managed_lines = _render_managed_traecli_hooks(cmd).split("\\n")
+    normalized = _normalize_traecli_hooks_list_indentation(contents)
+    cleaned = _remove_managed_traecli_hooks(normalized)
     lines = cleaned.split("\\n")
     hooks_index = None
     hooks_scalar = None
@@ -258,10 +378,13 @@ def _merge_traecli_hooks(contents, cmd):
             hooks_scalar = before_comment
             break
     if hooks_index is not None:
+        indent = _detect_traecli_hook_item_indent(lines, hooks_index)
+        managed_lines = _render_managed_traecli_hooks(cmd, indent=indent).split("\\n")
         if hooks_scalar and hooks_scalar != "":
             lines[hooks_index] = "hooks:"
         lines[hooks_index+1:hooks_index+1] = managed_lines
     else:
+        managed_lines = _render_managed_traecli_hooks(cmd, indent=2).split("\\n")
         while lines and lines[-1] == "":
             lines.pop()
         if lines:

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -1,8 +1,31 @@
 import XCTest
 @testable import CodeIsland
 import CodeIslandCore
+import Yams
 
 final class ConfigInstallerTests: XCTestCase {
+    private func yamlRootDict(_ yaml: String, file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
+        let any = try XCTUnwrap(try Yams.load(yaml: yaml), file: file, line: line)
+        if let d = any as? [String: Any] { return d }
+        if let d = any as? [AnyHashable: Any] {
+            var out: [String: Any] = [:]
+            out.reserveCapacity(d.count)
+            for (k, v) in d {
+                guard let ks = k as? String else { continue }
+                out[ks] = v
+            }
+            return out
+        }
+        XCTFail("YAML root is not a mapping", file: file, line: line)
+        return [:]
+    }
+
+    private func yamlHooks(_ yaml: String, file: StaticString = #filePath, line: UInt = #line) throws -> [[String: Any]] {
+        let root = try yamlRootDict(yaml, file: file, line: line)
+        let hooksAny = try XCTUnwrap(root["hooks"], file: file, line: line)
+        let hooks = try XCTUnwrap(hooksAny as? [Any], file: file, line: line)
+        return hooks.compactMap { $0 as? [String: Any] }
+    }
     func testRemoveManagedHookEntriesAlsoPrunesLegacyVibeIslandHooks() throws {
         let hooks: [String: Any] = [
             "SessionEnd": [
@@ -160,17 +183,19 @@ final class ConfigInstallerTests: XCTestCase {
 
         let merged = ConfigInstaller.mergeTraecliHooks(into: original)
 
-        XCTAssertTrue(merged.contains("hooks:\n"))
-        XCTAssertTrue(merged.contains("command: '"))
-        XCTAssertTrue(merged.contains("codeisland-bridge --source traecli"))
-        XCTAssertTrue(merged.contains("event: permission_request"))
+        let hooks = try! yamlHooks(merged)
+        XCTAssertEqual(hooks.count, 1)
+        let cmd = hooks.first?["command"] as? String
+        XCTAssertTrue(cmd?.contains("codeisland-bridge --source traecli") ?? false)
 
         // Managed block should be a SINGLE hook with multiple matchers. TraeCli may de-dup by
         // (type + command), so emitting one hook per event can drop most events.
-        XCTAssertEqual(merged.components(separatedBy: "- type: command").count - 1, 1)
-        XCTAssertTrue(merged.contains("event: pre_tool_use"))
-        XCTAssertTrue(merged.contains("event: post_tool_use"))
-        XCTAssertTrue(merged.contains("event: stop"))
+        let matchers = hooks.first?["matchers"] as? [Any]
+        let events = (matchers ?? []).compactMap { ($0 as? [String: Any])?["event"] as? String }
+        XCTAssertTrue(events.contains("permission_request"))
+        XCTAssertTrue(events.contains("pre_tool_use"))
+        XCTAssertTrue(events.contains("post_tool_use"))
+        XCTAssertTrue(events.contains("stop"))
     }
 
     func testMergeCocoHooksReplacesExistingManagedBlockWithoutTouchingUserHooks() {
@@ -201,12 +226,13 @@ hooks:
 
         let merged = ConfigInstaller.mergeTraecliHooks(into: original)
 
-        XCTAssertTrue(merged.contains("command: 'echo user-hook'"))
-        XCTAssertFalse(merged.contains("CODEISLAND_MANAGED_TRAECLI_HOOK"))
+        let hooks = try! yamlHooks(merged)
+        let commands = hooks.compactMap { $0["command"] as? String }
+        XCTAssertTrue(commands.contains("echo user-hook"))
 
         // New managed block should still contain a traecli bridge command.
-        XCTAssertEqual(merged.components(separatedBy: "codeisland-bridge --source traecli").count - 1, 1)
-        XCTAssertEqual(merged.components(separatedBy: "- type: command").count - 1, 2)
+        XCTAssertEqual(commands.filter { $0.contains("codeisland-bridge") && $0.contains("--source traecli") }.count, 1)
+        XCTAssertEqual(hooks.count, 2)
     }
 
     func testMergeTraecliHooksRemovesQuotedBridgeCommandToAvoidDuplicates() {
@@ -234,19 +260,42 @@ hooks:
 
         let merged = ConfigInstaller.mergeTraecliHooks(into: original)
 
-        // Old quoted command should be removed, and the new managed block inserted once.
-        XCTAssertEqual(merged.components(separatedBy: "codeisland-bridge").count - 1, 1)
-        XCTAssertEqual(merged.components(separatedBy: "--source traecli").count - 1, 1)
+        let hooks = try! yamlHooks(merged)
+        let commands = hooks.compactMap { $0["command"] as? String }
+        XCTAssertEqual(commands.filter { $0.contains("codeisland-bridge") }.count, 1)
+        XCTAssertEqual(commands.filter { $0.contains("--source traecli") }.count, 1)
     }
 
     func testMergeTraecliHooksHandlesHooksFlowSequenceWithoutBreakingYAML() {
         let original = "model: GPT-5.4\nhooks: []\n"
         let merged = ConfigInstaller.mergeTraecliHooks(into: original)
 
-        // Should rewrite hooks into a block list and inject our managed hook.
-        XCTAssertTrue(merged.contains("hooks:\n"))
-        XCTAssertFalse(merged.contains("hooks: []"))
-        XCTAssertEqual(merged.components(separatedBy: "--source traecli").count - 1, 1)
+        // Should rewrite hooks into a list and inject our managed hook.
+        let hooks = try! yamlHooks(merged)
+        let commands = hooks.compactMap { $0["command"] as? String }
+        XCTAssertEqual(commands.filter { $0.contains("--source traecli") }.count, 1)
+    }
+
+    func testMergeTraecliHooksNormalizesMixedIndentationToValidYAML() {
+        // Simulate a user file with 4-space indented list items, which previously could
+        // become invalid YAML when we injected a 2-space indented managed block.
+        let original = """
+model:
+    name: GPT-5.4
+hooks:
+    - type: command
+      command: echo user-hook
+      matchers:
+        - event: stop
+"""
+
+        let merged = ConfigInstaller.mergeTraecliHooks(into: original)
+        // Must be parseable and must contain both user + managed hook.
+        let hooks = try! yamlHooks(merged)
+        let commands = hooks.compactMap { $0["command"] as? String }
+        XCTAssertTrue(commands.contains("echo user-hook"))
+        XCTAssertEqual(commands.filter { $0.contains("codeisland-bridge") && $0.contains("--source traecli") }.count, 1)
+        XCTAssertEqual(hooks.count, 2)
     }
 
     func testMergeTraecliHooksIsIdempotent() {
@@ -284,8 +333,10 @@ hooks:
 
         let merged = ConfigInstaller.mergeTraecliHooks(into: original)
 
-        XCTAssertTrue(merged.contains("command: 'echo user-hook'"))
-        XCTAssertEqual(merged.components(separatedBy: "--source traecli").count - 1, 1)
+        let hooks = try! yamlHooks(merged)
+        let commands = hooks.compactMap { $0["command"] as? String }
+        XCTAssertTrue(commands.contains("echo user-hook"))
+        XCTAssertEqual(commands.filter { $0.contains("--source traecli") }.count, 1)
     }
 
     func testRemoveManagedTraecliHooksDeletesHookWhenCommandMatches() {
@@ -330,6 +381,8 @@ hooks:
         XCTAssertTrue(script.contains("TRAECLI_EVENTS"))
         XCTAssertTrue(script.contains("\"session_start\""))
         XCTAssertTrue(script.contains("\"session_end\""))
+        // Ensure remote TraeCli YAML merge has indentation repair to avoid invalid YAML.
+        XCTAssertTrue(script.contains("def _normalize_traecli_hooks_list_indentation"))
     }
 
     func testRemoteTraecliPermissionRequestRoutesAsPermissionAndUsesRemoteSessionNamespace() async throws {


### PR DESCRIPTION
使用 Yams 解析/合并 traecli.yaml，处理混合缩进导致的 YAML 失效，并同步修复远程安装脚本的注入/去重逻辑。