### PR TITLE
fix: 让 codex 自动配置遵循 $CODEX_HOME（本地 & ssh）

### DIFF
--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -57,14 +57,22 @@ enum HookFormat {
 struct CLIConfig {
     let name: String           // display name
     let source: String         // --source flag value
-    let configPath: String     // path to config file (relative to home)
+    let configPath: String     // path to config file (relative to home, or to rootOverride if set)
     let configKey: String      // top-level JSON key containing hooks ("hooks" for most)
     let format: HookFormat
     let events: [(String, Int, Bool)]  // (eventName, timeout, async)
     /// Events that require a minimum CLI version (eventName → minVersion like "2.1.89")
     var versionedEvents: [String: String] = [:]
+    /// Optional root directory override. When set, `configPath` is resolved relative to this
+    /// directory instead of the user's home (used by Codex to honor $CODEX_HOME).
+    var rootOverride: (@Sendable () -> String)? = nil
+    /// Optional override for the user-visible config path (e.g. "$CODEX_HOME/hooks.json").
+    var displayPathOverride: (@Sendable () -> String)? = nil
 
     var fullPath: String {
+        if let override = rootOverride {
+            return override() + "/" + configPath
+        }
         if configPath.hasPrefix("/") { return configPath }
         if configPath.hasPrefix("~/") {
             return NSHomeDirectory() + "/" + configPath.dropFirst(2)
@@ -73,6 +81,7 @@ struct CLIConfig {
     }
     var dirPath: String { (fullPath as NSString).deletingLastPathComponent }
     var displayConfigPath: String {
+        if let override = displayPathOverride { return override() }
         if configPath.hasPrefix("/") || configPath.hasPrefix("~/") { return configPath }
         return "~/\(configPath)"
     }
@@ -101,6 +110,27 @@ struct ConfigInstaller {
     private static let legacyBridgePath = NSHomeDirectory() + "/.claude/hooks/codeisland-bridge"
     private static let legacyHookScriptPath = NSHomeDirectory() + "/.claude/hooks/codeisland-hook.sh"
 
+    // MARK: - Codex home resolution
+
+    /// Resolve Codex's config directory. Honors $CODEX_HOME (with a leading `~` expanded);
+    /// falls back to `~/.codex`. Whitespace-only or empty values are treated as unset.
+    static func codexHome() -> String {
+        let raw = (ProcessInfo.processInfo.environment["CODEX_HOME"] ?? "")
+            .trimmingCharacters(in: .whitespaces)
+        guard !raw.isEmpty else { return NSHomeDirectory() + "/.codex" }
+        if raw == "~" { return NSHomeDirectory() }
+        if raw.hasPrefix("~/") { return NSHomeDirectory() + "/" + raw.dropFirst(2) }
+        return raw
+    }
+
+    /// User-visible form of a Codex config path (uses `$CODEX_HOME/...` when the env var
+    /// is set, otherwise `~/.codex/...`).
+    static func displayCodexPath(filename: String) -> String {
+        let raw = (ProcessInfo.processInfo.environment["CODEX_HOME"] ?? "")
+            .trimmingCharacters(in: .whitespaces)
+        return raw.isEmpty ? "~/.codex/\(filename)" : "$CODEX_HOME/\(filename)"
+    }
+
     // MARK: - All supported CLIs
 
     private static let builtInCLIs: [CLIConfig] = [
@@ -127,10 +157,10 @@ struct ConfigInstaller {
                 "PostToolUseFailure": "2.1.89",
             ]
         ),
-        // Codex
+        // Codex — honors $CODEX_HOME (falls back to ~/.codex)
         CLIConfig(
             name: "Codex", source: "codex",
-            configPath: ".codex/hooks.json", configKey: "hooks",
+            configPath: "hooks.json", configKey: "hooks",
             format: .nested,
             events: [
                 ("SessionStart", 5, false),
@@ -139,7 +169,9 @@ struct ConfigInstaller {
                 ("PreToolUse", 5, false),
                 ("PostToolUse", 5, false),
                 ("Stop", 5, false),
-            ]
+            ],
+            rootOverride: { ConfigInstaller.codexHome() },
+            displayPathOverride: { ConfigInstaller.displayCodexPath(filename: "hooks.json") }
         ),
         // Gemini CLI — timeout in milliseconds
         CLIConfig(
@@ -525,7 +557,7 @@ struct ConfigInstaller {
 
         // Codex requires codex_hooks = true in config.toml
         if isEnabled(source: "codex"),
-           fm.fileExists(atPath: NSHomeDirectory() + "/.codex") {
+           fm.fileExists(atPath: codexHome()) {
             enableCodexHooksConfig(fm: fm)
         }
 
@@ -660,7 +692,7 @@ struct ConfigInstaller {
         }
         // Codex config.toml: ensure codex_hooks = true
         if isEnabled(source: "codex"),
-           fm.fileExists(atPath: NSHomeDirectory() + "/.codex") {
+           fm.fileExists(atPath: codexHome()) {
             enableCodexHooksConfig(fm: fm)
         }
         // OpenCode plugin
@@ -1250,11 +1282,11 @@ struct ConfigInstaller {
 
     // MARK: - Codex config.toml
 
-    /// Ensure codex_hooks = true under [features] in ~/.codex/config.toml
-    /// so Codex actually fires hook events.
+    /// Ensure codex_hooks = true under [features] in $CODEX_HOME/config.toml
+    /// (or ~/.codex/config.toml when unset) so Codex actually fires hook events.
     @discardableResult
     private static func enableCodexHooksConfig(fm: FileManager) -> Bool {
-        let configPath = NSHomeDirectory() + "/.codex/config.toml"
+        let configPath = codexHome() + "/config.toml"
         var contents = ""
         if fm.fileExists(atPath: configPath) {
             contents = (try? String(contentsOfFile: configPath, encoding: .utf8)) ?? ""

--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -67,7 +67,13 @@ print(target)
 
     private static func configureRemoteHooks(host: RemoteHost) async -> RemoteCommandResult {
         let py = configureRemoteHooksScript(host: host)
-        return await runSSH(host: host, command: "python3 - <<'PY'\n\(py)\nPY", timeout: 30)
+        // Run via the remote user's login shell so ~/.zprofile / ~/.bash_profile etc. are
+        // sourced — that's how $CODEX_HOME (and similar) reach a non-interactive ssh session.
+        // base64 keeps the script intact regardless of shell quoting.
+        let encoded = Data(py.utf8).base64EncodedString()
+        let inner = "echo '\(encoded)' | base64 -d | python3"
+        let command = "\"${SHELL:-/bin/bash}\" -lc \"\(inner)\""
+        return await runSSH(host: host, command: command, timeout: 30)
     }
 
     static func configureRemoteHooksScript(host: RemoteHost) -> String {
@@ -85,6 +91,13 @@ hook_path = home / ".codeisland" / "codeisland-remote-hook.py"
 host_id = \(hostId)
 host_name = \(hostName)
 version = \(version)
+
+def _codex_home():
+    raw = (os.environ.get("CODEX_HOME") or "").strip()
+    if not raw:
+        return home / ".codex"
+    expanded = os.path.expanduser(raw)
+    return pathlib.Path(expanded)
 
 def ensure_json(path):
     if path.exists():
@@ -318,7 +331,7 @@ def ensure_toml_codex_hooks(path):
     path.write_text("\\n".join(lines).rstrip() + "\\n")
 
 def install_codex():
-    codex_root = home / ".codex"
+    codex_root = _codex_home()
     if not codex_root.exists() and shutil.which("codex") is None:
         return "Codex skipped"
 

--- a/Tests/CodeIslandTests/CodexHomeTests.swift
+++ b/Tests/CodeIslandTests/CodexHomeTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import CodeIsland
+
+final class CodexHomeTests: XCTestCase {
+    private var savedValue: String?
+
+    override func setUp() {
+        super.setUp()
+        savedValue = ProcessInfo.processInfo.environment["CODEX_HOME"]
+        unsetenv("CODEX_HOME")
+    }
+
+    override func tearDown() {
+        if let savedValue {
+            setenv("CODEX_HOME", savedValue, 1)
+        } else {
+            unsetenv("CODEX_HOME")
+        }
+        super.tearDown()
+    }
+
+    func testCodexHomeDefaultsToDotCodexWhenUnset() {
+        unsetenv("CODEX_HOME")
+        XCTAssertEqual(ConfigInstaller.codexHome(), NSHomeDirectory() + "/.codex")
+    }
+
+    func testCodexHomeUsesAbsolutePath() {
+        setenv("CODEX_HOME", "/abs/path", 1)
+        XCTAssertEqual(ConfigInstaller.codexHome(), "/abs/path")
+    }
+
+    func testCodexHomeExpandsTilde() {
+        setenv("CODEX_HOME", "~/foo", 1)
+        XCTAssertEqual(ConfigInstaller.codexHome(), NSHomeDirectory() + "/foo")
+    }
+
+    func testCodexHomeBareTildeBecomesHome() {
+        setenv("CODEX_HOME", "~", 1)
+        XCTAssertEqual(ConfigInstaller.codexHome(), NSHomeDirectory())
+    }
+
+    func testCodexHomeEmptyStringFallsBack() {
+        setenv("CODEX_HOME", "", 1)
+        XCTAssertEqual(ConfigInstaller.codexHome(), NSHomeDirectory() + "/.codex")
+    }
+
+    func testCodexHomeWhitespaceFallsBack() {
+        setenv("CODEX_HOME", "   ", 1)
+        XCTAssertEqual(ConfigInstaller.codexHome(), NSHomeDirectory() + "/.codex")
+    }
+
+    func testDisplayCodexPathUsesEnvNameWhenSet() {
+        setenv("CODEX_HOME", "/abs/path", 1)
+        XCTAssertEqual(ConfigInstaller.displayCodexPath(filename: "hooks.json"), "$CODEX_HOME/hooks.json")
+    }
+
+    func testDisplayCodexPathFallsBackWhenUnset() {
+        unsetenv("CODEX_HOME")
+        XCTAssertEqual(ConfigInstaller.displayCodexPath(filename: "hooks.json"), "~/.codex/hooks.json")
+    }
+}


### PR DESCRIPTION
## 背景

codex 自身解析配置目录的顺序是：先看 `$CODEX_HOME`，没有再退回 `~/.codex`。但当前我们做 codex 自动配置时，无论本地还是 ssh，都直接拼了 `~/.codex/`：

- 本地：`ConfigInstaller` 把 `hooks.json` 写到 `~/.codex/hooks.json`，并在 `~/.codex/config.toml` 里改 `codex_hooks = true`。
- 远端：`RemoteInstaller` 里嵌入的 Python 脚本同样硬编码 `home / ".codex"`。

对于把 `CODEX_HOME` 指到别处的用户，钩子写入的目录 codex 根本不会读 —— 安装看起来成功，运行时一个事件都不会触发。

## 改动

**ConfigInstaller.swift**
- 新增 `codexHome()` 解析器：读 `$CODEX_HOME`，处理 `~` / `~/x` 展开，空串和纯空白都视为未设置，回退到 `~/.codex`。
- 新增 `displayCodexPath(filename:)`：UI/日志里显示 `\$CODEX_HOME/hooks.json` 或 `~/.codex/hooks.json`，跟实际写入位置保持一致。
- `CLIConfig` 加了两个可选闭包 `rootOverride` / `displayPathOverride`，特例本地化在 codex 一条记录里，其它 CLI 完全不受影响。
- `installAll` / `verifyAndRepair` / `enableCodexHooksConfig` 里原本拼 `NSHomeDirectory() + "/.codex"` 的三处都改成走 `codexHome()`。

**RemoteInstaller.swift**
- 远端 Python 脚本里加 `_codex_home()`：同样的 `$CODEX_HOME` → `~/.codex` 回退逻辑，`install_codex` 走它。
- ssh 调用改走登录 shell：`\"\${SHELL:-/bin/bash}\" -lc \"...\"`，让远端 `~/.zprofile` / `~/.bash_profile` 里 export 的 `CODEX_HOME` 能进到非交互会话。Python 脚本用 base64 编码再喂给 stdin，避开嵌套 heredoc 的引号问题。

## 测试

- `Tests/CodeIslandTests/CodexHomeTests.swift` 覆盖 8 种情况：未设置 / 绝对路径 / `~/foo` / 裸 `~` / 空串 / 纯空白 / display 名走 env / display 名回退。
- 全量 `swift test`：197/197 通过，没有回归。

## 验证步骤

1. 不设 `CODEX_HOME`，安装 hooks → `~/.codex/hooks.json` 与 `config.toml` 正常更新。
2. `launchctl setenv CODEX_HOME ~/codex-custom` 后重启 app，再次安装 → `~/codex-custom/` 下生成两个文件，`~/.codex/` 没被碰过。
3. 远端机器在 `~/.zprofile` 里 `export CODEX_HOME=$HOME/codex-custom`，触发远端安装 → `~/codex-custom/hooks.json` 写入成功。