### PR TITLE
feat: add WorkBuddy to sourceToNativeAppBundleId for one-click jump

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -33,6 +33,7 @@ struct TerminalActivator {
         "codybuddycn": "com.tencent.codebuddy.cn",
         "stepfun": "com.stepfun.app",
         "opencode": "ai.opencode.desktop",
+        "workbuddy": "com.workbuddy.workbuddy",
     ]
 
     /// Bundle IDs of apps that have both APP and CLI modes.
@@ -48,6 +49,7 @@ struct TerminalActivator {
         "com.tencent.codebuddy.cn": "CodyBuddyCN",
         "com.stepfun.app": "StepFun",
         "ai.opencode.desktop": "OpenCode",
+        "com.workbuddy.workbuddy": "WorkBuddy",
     ]
 
     static func activate(session: SessionSnapshot, sessionId: String? = nil) {


### PR DESCRIPTION
## Summary

- Add `"workbuddy": "com.workbuddy.workbuddy"` to the `sourceToNativeAppBundleId` dictionary in `TerminalActivator.swift`
- WorkBuddy sessions report `source` as `"workbuddy"` via `codeisland-bridge --source workbuddy`, but clicking them in CodeIsland cannot jump to the WorkBuddy desktop app because there is no mapping entry
- This one-line fix enables one-click jump from CodeIsland to WorkBuddy app

## Test plan

- [x] Verified `com.workbuddy.workbuddy` is the correct `CFBundleIdentifier` for WorkBuddy.app
- [ ] Build CodeIsland from source and confirm clicking a WorkBuddy session activates the WorkBuddy app