### PR TITLE
fix: prevent Sparkle crash in DEBUG mode when running without bundle ID

### DIFF
--- a/Sources/CodeIsland/UpdateChecker.swift
+++ b/Sources/CodeIsland/UpdateChecker.swift
@@ -42,6 +42,14 @@ final class UpdateChecker: NSObject, ObservableObject {
 
     /// Wire up Sparkle. Call once from `AppDelegate.applicationDidFinishLaunching`.
     func start() {
+        #if DEBUG
+        // Sparkle crashes if we run without a proper Bundle ID (e.g. raw executable via Xcode/SPM)
+        if Bundle.main.bundleIdentifier == nil {
+            Self.log.info("No Bundle ID detected in DEBUG mode — skipping Sparkle")
+            return
+        }
+        #endif
+
         if isHomebrewInstall {
             Self.log.info("Homebrew install detected — disabling Sparkle auto-checks")
             updater.automaticallyChecksForUpdates = false


### PR DESCRIPTION

  fix: prevent Sparkle crash in DEBUG mode when running without bundle ID

  PR 描述 (Description)

  问题背景 (Problem)
  当直接通过 Xcode 运行项目或在终端执行调试二进制文件时，由于此时程序不是以完整的 .app
  包形式运行，系统无法识别 CFBundleIdentifier。这会导致内置的 Sparkle
  更新框架在启动时抛出致命错误（Fatal Error），表现为应用启动后卡死或直接闪退。

  解决方案 (Solution)
  在 UpdateChecker.swift 的启动逻辑中增加了环境检测：
   * 检测当前是否处于 DEBUG 编译模式。
   * 检测 Bundle.main.bundleIdentifier 是否为空。
   * 如果满足以上条件，则跳过 Sparkle 的初始化，从而避免因缺少身份标识导致的崩溃。

  影响 (Impact)
   * 开发者体验：开发者现在可以顺滑地在 Xcode 中进行调试，不再受身份标识报错的困扰。
   * 正式版本：由于使用了 #if DEBUG 宏，此改动不会影响正式发布版的自动更新功能。