### PR TITLE
fix: 避免已完成的更新检查被 abort 回调覆盖

### DIFF
--- a/Sources/CodeIsland/UpdateChecker.swift
+++ b/Sources/CodeIsland/UpdateChecker.swift
@@ -91,7 +91,9 @@ extension UpdateChecker: SPUUpdaterDelegate {
         let description = error.localizedDescription
         Task { @MainActor in
             Self.log.debug("Sparkle aborted: \(description)")
-            self.state = .failed(description)
+            if self.state == .checking {
+                self.state = .failed(description)
+            }
         }
     }
 }


### PR DESCRIPTION
## 概要

- 避免 Sparkle 的 abort 回调覆盖已经完成的更新检查状态。
- 保留手动检查仍在进行中时的真实失败提示。

Closes #137

## 验证

- swift build
