### PR TITLE
fix: 修复 AskUserQuestion 在新版 Claude Code 下的点击回答异常

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -1229,8 +1229,9 @@ final class AppState {
         extractMetadata(into: &sessions, sessionId: sessionId, event: event)
         tryMonitorSession(sessionId)
 
+        let originalQuestions = event.toolInput?["questions"] as? [[String: Any]]
         var askItems: [AskUserQuestionItem] = []
-        if let questions = event.toolInput?["questions"] as? [[String: Any]] {
+        if let questions = originalQuestions {
             var usedAnswerKeys = Set<String>()
             askItems = questions.enumerated().compactMap { index, item in
                 let questionText = item["question"] as? String ?? "Question"
@@ -1280,12 +1281,18 @@ final class AppState {
         }
 
         guard !askItems.isEmpty else {
+            let updatedInput = askUserQuestionUpdatedInput(
+                event: event,
+                answers: [:],
+                answer: nil,
+                originalQuestions: originalQuestions
+            )
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
-                        "updatedInput": ["answers": [:] as [String: String]]
+                        "updatedInput": updatedInput
                     ] as [String: Any]
                 ] as [String: Any]
             ]
@@ -1332,14 +1339,18 @@ final class AppState {
         let responseData: Data
         if pending.isFromPermission {
             let answerKey = pending.question.header ?? "answer"
+            let updatedInput = askUserQuestionUpdatedInput(
+                event: pending.event,
+                answers: [answerKey: answer],
+                answer: answer,
+                originalQuestions: pending.event.toolInput?["questions"] as? [[String: Any]]
+            )
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
-                        "updatedInput": [
-                            "answers": [answerKey: answer]
-                        ]
+                        "updatedInput": updatedInput
                     ] as [String: Any]
                 ] as [String: Any]
             ]
@@ -1378,14 +1389,18 @@ final class AppState {
                 let answerKey = pending.question.header ?? "answer"
                 answersDict[answerKey] = answers.first?.answer ?? ""
             }
+            let updatedInput = askUserQuestionUpdatedInput(
+                event: pending.event,
+                answers: answersDict,
+                answer: answers.first?.answer,
+                originalQuestions: pending.event.toolInput?["questions"] as? [[String: Any]]
+            )
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
-                        "updatedInput": [
-                            "answers": answersDict
-                        ]
+                        "updatedInput": updatedInput
                     ] as [String: Any]
                 ] as [String: Any]
             ]
@@ -1405,6 +1420,23 @@ final class AppState {
 
         showNextPending()
         refreshDerivedState()
+    }
+
+    private func askUserQuestionUpdatedInput(
+        event: HookEvent,
+        answers: [String: String],
+        answer: String?,
+        originalQuestions: [[String: Any]]?
+    ) -> [String: Any] {
+        var updatedInput = event.toolInput ?? [:]
+        if let originalQuestions {
+            updatedInput["questions"] = originalQuestions
+        }
+        updatedInput["answers"] = answers
+        if let answer {
+            updatedInput["answer"] = answer
+        }
+        return updatedInput
     }
 
     func skipQuestion() {

--- a/Tests/CodeIslandTests/AppStateQuestionFlowTests.swift
+++ b/Tests/CodeIslandTests/AppStateQuestionFlowTests.swift
@@ -7,14 +7,15 @@ final class AppStateQuestionFlowTests: XCTestCase {
 
     // MARK: - Multi-question answers
 
-    func testAskUserQuestionMultiQuestionReturnsAllAnswers() async throws {
+    func testAskUserQuestionMultiQuestionReturnsQuestionsAndAnswers() async throws {
         let appState = AppState()
+        let questions = [
+            question(header: "工作模式", text: "你希望我接下来以哪种方式协作？", options: ["直接执行", "先给方案"]),
+            question(header: "输出风格", text: "你更喜欢我用哪种回答风格？", options: ["极简", "平衡"]),
+        ]
         let event = try makeAskUserQuestionEvent(
             sessionId: "s-1",
-            questions: [
-                question(header: "工作模式", text: "你希望我接下来以哪种方式协作？", options: ["直接执行", "先给方案"]),
-                question(header: "输出风格", text: "你更喜欢我用哪种回答风格？", options: ["极简", "平衡"]),
-            ]
+            questions: questions
         )
 
         let responseTask = Task<Data, Never> {
@@ -32,6 +33,12 @@ final class AppStateQuestionFlowTests: XCTestCase {
         ])
 
         let responseData = await responseTask.value
+        let updatedInput = try extractUpdatedInput(from: responseData)
+        let returnedQuestions = try XCTUnwrap(updatedInput["questions"] as? [[String: Any]])
+        XCTAssertEqual(returnedQuestions.count, questions.count)
+        XCTAssertEqual(returnedQuestions[0]["question"] as? String, questions[0]["question"] as? String)
+        XCTAssertEqual(returnedQuestions[1]["question"] as? String, questions[1]["question"] as? String)
+
         let answers = try extractAnswers(from: responseData)
         XCTAssertEqual(answers["工作模式"] as? String, "先给方案")
         XCTAssertEqual(answers["输出风格"] as? String, "平衡")
@@ -340,11 +347,15 @@ final class AppStateQuestionFlowTests: XCTestCase {
         return result
     }
 
-    private func extractAnswers(from responseData: Data) throws -> [String: Any] {
+    private func extractUpdatedInput(from responseData: Data) throws -> [String: Any] {
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: responseData) as? [String: Any])
         let hookSpecificOutput = try XCTUnwrap(json["hookSpecificOutput"] as? [String: Any])
         let decision = try XCTUnwrap(hookSpecificOutput["decision"] as? [String: Any])
-        let updatedInput = try XCTUnwrap(decision["updatedInput"] as? [String: Any])
+        return try XCTUnwrap(decision["updatedInput"] as? [String: Any])
+    }
+
+    private func extractAnswers(from responseData: Data) throws -> [String: Any] {
+        let updatedInput = try extractUpdatedInput(from: responseData)
         return try XCTUnwrap(updatedInput["answers"] as? [String: Any])
     }
 


### PR DESCRIPTION
## 背景

升级 Claude Code 后，通过点击选项回答 `AskUserQuestion` 时会报错：

```text
Error: undefined is not an object (evaluating 'H.map')
```

问题出现在 `AskUserQuestion` 通过 `PermissionRequest` 回写结果时，`updatedInput` 只返回了 `answers`，没有保留原始 `questions`。这会导致新版 Claude Code 在处理问答结果时拿到不完整的 payload，从而在点击选项回答时触发前端异常。

Fixes #150

[claude code 文档说明](https://code.claude.com/docs/en/hooks)

<img width="1496" height="875" alt="image" src="https://github.com/user-attachments/assets/1e427a67-919b-471d-9658-b3ce3222066a" />

## 变更内容

- 保留 `AskUserQuestion` 原始 `questions` 输入
- 统一通过 helper 构造 `updatedInput`
- 回写结果时同时返回：
  - `questions`
  - `answers`
- 单题场景继续保留 `answer` 字段，兼容旧行为
- 补充回归测试，校验返回 payload 同时包含 `questions` 和 `answers`

## 兼容性

这次修复是兼容性的：

- 对旧行为保持兼容：继续返回 `answers`
- 对单题旧路径保持兼容：继续返回 `answer`
- 对新版 Claude Code 兼容：补充返回原始 `questions`

## 验证

已执行：

- `swift test --filter AppStateQuestionFlowTests/testAskUserQuestionMultiQuestionReturnsQuestionsAndAnswers`
- `swift test --filter AppStateQuestionFlowTests`
- `swift build`

结果：

- 问答流程相关测试全部通过
- 包构建通过

## 影响范围

- `Sources/CodeIsland/AppState.swift`
- `Tests/CodeIslandTests/AppStateQuestionFlowTests.swift`

