### PR TITLE
fix: preserve original questions in AskUserQuestion hook response

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -1280,12 +1280,16 @@ final class AppState {
         }
 
         guard !askItems.isEmpty else {
+            var updatedInput: [String: Any] = ["answers": [:] as [String: String]]
+            if let origQuestions = event.toolInput?["questions"] {
+                updatedInput["questions"] = origQuestions
+            }
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
-                        "updatedInput": ["answers": [:] as [String: String]]
+                        "updatedInput": updatedInput
                     ] as [String: Any]
                 ] as [String: Any]
             ]
@@ -1332,14 +1336,16 @@ final class AppState {
         let responseData: Data
         if pending.isFromPermission {
             let answerKey = pending.question.header ?? "answer"
+            var updatedInput: [String: Any] = ["answers": [answerKey: answer]]
+            if let origQuestions = pending.event.toolInput?["questions"] {
+                updatedInput["questions"] = origQuestions
+            }
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
-                        "updatedInput": [
-                            "answers": [answerKey: answer]
-                        ]
+                        "updatedInput": updatedInput
                     ] as [String: Any]
                 ] as [String: Any]
             ]
@@ -1378,14 +1384,16 @@ final class AppState {
                 let answerKey = pending.question.header ?? "answer"
                 answersDict[answerKey] = answers.first?.answer ?? ""
             }
+            var updatedInput: [String: Any] = ["answers": answersDict]
+            if let origQuestions = pending.event.toolInput?["questions"] {
+                updatedInput["questions"] = origQuestions
+            }
             let obj: [String: Any] = [
                 "hookSpecificOutput": [
                     "hookEventName": "PermissionRequest",
                     "decision": [
                         "behavior": "allow",
-                        "updatedInput": [
-                            "answers": answersDict
-                        ]
+                        "updatedInput": updatedInput
                     ] as [String: Any]
                 ] as [String: Any]
             ]


### PR DESCRIPTION
## Summary
- Fixes #157 — clicking a selection for `AskUserQuestion` in CodeIsland crashes Claude CLI with `undefined is not an object (evaluating 'H.map')`
- The `updatedInput` in the PermissionRequest hook response only contained `answers`, causing Claude CLI to lose the original `questions` array
- Now includes `event.toolInput["questions"]` in `updatedInput` at all three response paths in `AppState.swift`

## Test plan
- [ ] Trigger an `AskUserQuestion` prompt (e.g. one with multiple choice options) while CodeIsland hook is active
- [ ] Select an option in CodeIsland — should no longer produce `H.map` error
- [ ] Verify the answer is correctly received by Claude CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)