### PR TITLE
feat: add Kaku terminal tab-level jump and visibility detection support

### DIFF
--- a/Sources/CodeIsland/ProcessRunner.swift
+++ b/Sources/CodeIsland/ProcessRunner.swift
@@ -7,6 +7,19 @@ import Foundation
 /// Drains stdout on a background queue so a full pipe buffer cannot wedge the
 /// child between writes and our wait().
 enum ProcessRunner {
+    /// Resolve TTY device path for a given PID via `ps -o tty=`.
+    /// Returns nil when ps is unavailable, the PID is invalid, has no TTY, or reports "?".
+    /// Thread-safe and fast (sub-millisecond for local processes).
+    static func ttyForPid(_ pid: pid_t) -> String? {
+        guard pid > 0 else { return nil }
+        guard let data = run(path: "/bin/ps", args: ["-o", "tty=", "-p", "\(pid)"], timeout: 5),
+              let tty = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !tty.isEmpty, tty != "?"
+        else { return nil }
+        return tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+    }
+
     /// Reference cell for the pipe drain so the closure and the calling thread
     /// share storage cleanly. Synchronization is provided by the `drained`
     /// semaphore (signal happens-before wait), so `@unchecked Sendable` is

--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -2,7 +2,7 @@ import AppKit
 import CodeIslandCore
 
 /// Activates the terminal window/tab running a specific Claude Code session.
-/// Supports tab-level switching for: Ghostty, iTerm2, Terminal.app, WezTerm, kitty.
+/// Supports tab-level switching for: Ghostty, iTerm2, Terminal.app, WezTerm, Kaku, kitty.
 /// Falls back to app-level activation for: Alacritty, Warp, Hyper, Tabby, Rio.
 struct TerminalActivator {
     private static let knownTerminals: [(name: String, bundleId: String)] = [
@@ -10,6 +10,7 @@ struct TerminalActivator {
         ("Ghostty", "com.mitchellh.ghostty"),
         ("iTerm2", "com.googlecode.iterm2"),
         ("WezTerm", "com.github.wez.wezterm"),
+        ("Kaku", "fun.tw93.kaku"),
         ("kitty", "net.kovidgoyal.kitty"),
         ("Alacritty", "org.alacritty"),
         ("Warp", "dev.warp.Warp-Stable"),
@@ -168,6 +169,11 @@ struct TerminalActivator {
 
         if lower.contains("wezterm") || lower.contains("wez") {
             activateWezTerm(ttyPath: effectiveTty, cwd: session.cwd)
+            return
+        }
+
+        if lower.contains("kaku") || session.termBundleId == "fun.tw93.kaku" {
+            activateKaku(ttyPath: effectiveTty, cwd: session.cwd, cliPid: session.cliPid)
             return
         }
 
@@ -670,6 +676,52 @@ struct TerminalActivator {
         }
     }
 
+    // MARK: - Kaku (CLI: kaku cli list + activate-pane; JSON uses pane_id, not tab_id like WezTerm)
+
+    /// Activate a Kaku pane by TTY resolved from cliPid, with CWD fallback.
+    /// Uses `ps -o tty=` on the CLI's PID to get the real TTY (bypassing the
+    /// "/dev/tty" issue in hook/bridge TTY capture), then matches against
+    /// `kaku cli list --format json`.
+    private static func activateKaku(ttyPath: String?, cwd: String?, cliPid: pid_t?) {
+        bringToFront("Kaku")
+        guard let bin = findBinary("kaku", extraPaths: [
+            "/Applications/Kaku.app/Contents/MacOS/kaku",
+            NSHomeDirectory() + "/Applications/Kaku.app/Contents/MacOS/kaku",
+        ]) else { return }
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let json = runProcess(bin, args: ["cli", "list", "--format", "json"]),
+                  let panes = try? JSONSerialization.jsonObject(with: json) as? [[String: Any]]
+            else { return }
+
+            // Strategy 1: resolve TTY from cliPid via ps (most reliable)
+            var paneId: Int? = resolvePaneByCliPid(cliPid, panes: panes)
+            // Strategy 2: match by TTY path (skip "/dev/tty" — it's the controlling TTY, not specific)
+            if paneId == nil, let tty = ttyPath, tty != "/dev/tty" {
+                paneId = panes.first(where: { ($0["tty_name"] as? String) == tty })?["pane_id"] as? Int
+            }
+            // Strategy 3: match by CWD
+            if paneId == nil, let cwd = cwd {
+                let cwdUrl = "file://" + cwd
+                paneId = panes.first(where: {
+                    guard let paneCwd = $0["cwd"] as? String else { return false }
+                    return paneCwd == cwdUrl || paneCwd == cwd
+                })?["pane_id"] as? Int
+            }
+
+            guard let id = paneId else { return }
+            _ = runProcess(bin, args: ["cli", "activate-pane", "--pane-id", "\(id)"])
+        }
+    }
+
+    /// Resolve pane by looking up the CLI process's TTY via `ps`.
+    /// Falls back to nil when ps is unavailable or the PID has no TTY.
+    /// Delegates to ProcessRunner.ttyForPid to avoid duplicating ps parsing.
+    private static func resolvePaneByCliPid(_ cliPid: pid_t?, panes: [[String: Any]]) -> Int? {
+        guard let pid = cliPid, pid > 0 else { return nil }
+        guard let tty = ProcessRunner.ttyForPid(pid) else { return nil }
+        return panes.first(where: { ($0["tty_name"] as? String) == tty })?["pane_id"] as? Int
+    }
+
     // MARK: - kitty (CLI: kitten @ focus-window/focus-tab)
 
     private static func activateKitty(windowId: String?, cwd: String?, source: String = "claude") {
@@ -822,6 +874,7 @@ struct TerminalActivator {
         else if lower.contains("iterm") { name = "iTerm2" }
         else if lower.contains("terminal") || lower.contains("apple_terminal") { name = "Terminal" }
         else if lower.contains("wezterm") || lower.contains("wez") { name = "WezTerm" }
+        else if lower == "kaku" { name = "Kaku" }
         else if lower.contains("alacritty") || lower.contains("lacritty") { name = "Alacritty" }
         else if lower.contains("kitty") { name = "kitty" }
         else if lower.contains("warp") { name = "Warp" }

--- a/Sources/CodeIsland/TerminalVisibilityDetector.swift
+++ b/Sources/CodeIsland/TerminalVisibilityDetector.swift
@@ -93,6 +93,9 @@ struct TerminalVisibilityDetector {
         if bid.contains("wezterm") {
             return isWezTermTabActive(session)
         }
+        if bid == "fun.tw93.kaku" {
+            return isKakuTabActive(session)
+        }
         if bid.contains("kitty") {
             return isKittyWindowActive(session)
         }
@@ -105,6 +108,7 @@ struct TerminalVisibilityDetector {
             if lower.contains("iterm") { return isITermSessionActive(session) }
             if lower == "ghostty" { return isGhosttyTabActive(session) }
             if lower.contains("wezterm") || lower.contains("wez") { return isWezTermTabActive(session) }
+            if lower == "kaku" { return isKakuTabActive(session) }
             if lower.contains("kitty") { return isKittyWindowActive(session) }
             // Don't match "terminal" here — Warp sets TERM_PROGRAM=Apple_Terminal
         }
@@ -207,6 +211,42 @@ struct TerminalVisibilityDetector {
         return false
     }
 
+    /// Check if Kaku's active pane matches by TTY or CWD.
+    /// Mirrors the WezTerm list approach, but Kaku uses pane_id (not tab_id).
+    /// Adds cliPid→ps TTY resolution as the most reliable strategy.
+    private static func isKakuTabActive(_ session: SessionSnapshot) -> Bool {
+        guard let bin = findBinary("kaku", extraPaths: [
+            "/Applications/Kaku.app/Contents/MacOS/kaku",
+            NSHomeDirectory() + "/Applications/Kaku.app/Contents/MacOS/kaku",
+        ]) else { return false }
+        guard let json = runProcess(bin, args: ["cli", "list", "--format", "json"]),
+              let panes = try? JSONSerialization.jsonObject(with: json) as? [[String: Any]] else { return false }
+
+        // In Kaku all panes may report is_active=true, so we match by TTY or CWD
+        // instead of relying on is_active.
+        // Strategy 1: resolve TTY from cliPid via ps (most reliable)
+        if let tty = resolveTtyFromPid(session.cliPid) {
+            if panes.contains(where: { ($0["tty_name"] as? String) == tty }) {
+                return true
+            }
+        }
+        // Strategy 2: match by session TTY path (skip "/dev/tty" — controlling TTY, not specific)
+        if let tty = session.ttyPath, tty != "/dev/tty" {
+            if panes.contains(where: { ($0["tty_name"] as? String) == tty }) {
+                return true
+            }
+        }
+        // Strategy 3: match by CWD
+        if let cwd = session.cwd {
+            let cwdUrl = "file://" + cwd
+            if panes.contains(where: {
+                guard let paneCwd = $0["cwd"] as? String else { return false }
+                return paneCwd == cwdUrl || paneCwd == cwd
+            }) { return true }
+        }
+        return false
+    }
+
     // MARK: - kitty
 
     /// Check if kitty's focused window matches by window ID or CWD.
@@ -278,8 +318,16 @@ struct TerminalVisibilityDetector {
         return result.stringValue
     }
 
-    private static func findBinary(_ name: String) -> String? {
-        let paths = [
+    /// Resolve TTY from CLI process PID via `ps`.
+    /// Delegates to ProcessRunner.ttyForPid for shared ps parsing (avoids duplication
+    /// with TerminalActivator.resolvePaneByCliPid).
+    private static func resolveTtyFromPid(_ cliPid: pid_t?) -> String? {
+        guard let pid = cliPid, pid > 0 else { return nil }
+        return ProcessRunner.ttyForPid(pid)
+    }
+
+    private static func findBinary(_ name: String, extraPaths: [String] = []) -> String? {
+        let paths = extraPaths + [
             "/opt/homebrew/bin/\(name)",
             "/usr/local/bin/\(name)",
             "/usr/bin/\(name)",

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -367,6 +367,7 @@ public struct SessionSnapshot: Sendable {
             if lower.contains("kitty") { return "Kitty" }
             if lower.contains("alacritty") { return "Alacritty" }
             if lower.contains("wezterm") { return "WezTerm" }
+            if lower.contains("kaku") { return "Kaku" }
             // IDE integrated terminals
             if lower.contains("vscode") || lower.contains("vscodium") { return "VS Code" }
             if lower == "com.trae.app" { return "Trae" }


### PR DESCRIPTION
issue: #159 
- Activate Kaku pane by TTY (resolved from cliPid via ps) or CWD fallback
- Detect Kaku tab visibility using the same multi-strategy matching
- Extract ProcessRunner.ttyForPid as shared ps TTY resolution utility
- Add Kaku to knownTerminals, bringToFront, terminalName, and detector routing for end-to-end support