### PR TITLE
Fix Codex Always Allow by persisting rules

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -1082,7 +1082,11 @@ final class AppState {
         let sessionId = pending.event.sessionId ?? "default"
         dismissedPermissionSessionIds.remove(sessionId)
         let responseData: Data
-        if always {
+        if always, CodexPermissionRules.isCodexEvent(pending.event) {
+            _ = CodexPermissionRules().persistAlwaysAllowRule(for: pending.event)
+            let response = #"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#
+            responseData = Data(response.utf8)
+        } else if always {
             let toolName = pending.event.toolName ?? ""
             let obj: [String: Any] = [
                 "hookSpecificOutput": [

--- a/Sources/CodeIsland/CodexPermissionRules.swift
+++ b/Sources/CodeIsland/CodexPermissionRules.swift
@@ -1,0 +1,198 @@
+import Foundation
+import CodeIslandCore
+
+struct CodexPermissionRules {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    static func isCodexEvent(_ event: HookEvent) -> Bool {
+        SessionSnapshot.normalizedSupportedSource(event.rawJSON["_source"] as? String) == "codex"
+    }
+
+    static func prefixPattern(for event: HookEvent) -> [String]? {
+        if let suggested = findSuggestedPrefixRule(in: event.rawJSON) {
+            return suggested
+        }
+
+        guard event.toolName == "Bash",
+              let command = event.toolInput?["command"] as? String else {
+            return nil
+        }
+
+        return shellPrefix(from: command, maxTokens: 3)
+    }
+
+    @discardableResult
+    func persistAlwaysAllowRule(for event: HookEvent) -> Bool {
+        guard let pattern = Self.prefixPattern(for: event), !pattern.isEmpty else {
+            return false
+        }
+
+        let rulesDirectory = ConfigInstaller.codexHome() + "/rules"
+        let rulesPath = rulesDirectory + "/codeisland.rules"
+        let block = Self.ruleBlock(for: pattern)
+        let patternLine = Self.patternLine(for: pattern)
+
+        do {
+            try fileManager.createDirectory(atPath: rulesDirectory, withIntermediateDirectories: true)
+
+            let existing = (try? String(contentsOfFile: rulesPath, encoding: .utf8)) ?? ""
+            if existing.contains(patternLine), existing.contains(#"decision = "allow""#) {
+                return true
+            }
+
+            let separator = existing.isEmpty || existing.hasSuffix("\n") ? "" : "\n"
+            let updated = existing + separator + block
+            try updated.write(toFile: rulesPath, atomically: true, encoding: .utf8)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private static func patternLine(for pattern: [String]) -> String {
+        "pattern = [\(pattern.map(quotedRuleString).joined(separator: ", "))]"
+    }
+
+    private static func ruleBlock(for pattern: [String]) -> String {
+        """
+        # Added by CodeIsland when "Always Allow" is clicked for Codex.
+        prefix_rule(
+            \(patternLine(for: pattern)),
+            decision = "allow",
+            justification = "Allowed from CodeIsland Always Allow",
+        )
+
+        """
+    }
+
+    private static func quotedRuleString(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    private static func findSuggestedPrefixRule(in value: Any) -> [String]? {
+        if let dictionary = value as? [String: Any] {
+            for key in ["prefix_rule", "prefixRule"] {
+                if let pattern = stringArray(from: dictionary[key]) {
+                    return pattern
+                }
+            }
+
+            for nested in dictionary.values {
+                if let pattern = findSuggestedPrefixRule(in: nested) {
+                    return pattern
+                }
+            }
+        } else if let array = value as? [Any] {
+            for nested in array {
+                if let pattern = findSuggestedPrefixRule(in: nested) {
+                    return pattern
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func stringArray(from value: Any?) -> [String]? {
+        if let pattern = value as? [String], !pattern.isEmpty {
+            return pattern
+        }
+        if let dictionary = value as? [String: Any],
+           let pattern = dictionary["pattern"] as? [String],
+           !pattern.isEmpty {
+            return pattern
+        }
+        return nil
+    }
+
+    private static func shellPrefix(from command: String, maxTokens: Int) -> [String]? {
+        var tokens: [String] = []
+        var current = ""
+        var quote: Character?
+        var escaping = false
+        var index = command.startIndex
+
+        func appendCurrentToken() {
+            guard !current.isEmpty else { return }
+            tokens.append(current)
+            current = ""
+        }
+
+        while index < command.endIndex {
+            let char = command[index]
+            let next = command.index(after: index)
+
+            if escaping {
+                current.append(char)
+                escaping = false
+                index = next
+                continue
+            }
+
+            if char == "\\" {
+                escaping = true
+                index = next
+                continue
+            }
+
+            if let activeQuote = quote {
+                if char == activeQuote {
+                    quote = nil
+                } else {
+                    current.append(char)
+                }
+                index = next
+                continue
+            }
+
+            if char == "'" || char == "\"" {
+                quote = char
+                index = next
+                continue
+            }
+
+            if char == "$", next < command.endIndex, command[next] == "(" {
+                appendCurrentToken()
+                break
+            }
+
+            if char == "\n" || char == "|" || char == ";" || char == "<" || char == ">" || char == "&" {
+                appendCurrentToken()
+                break
+            }
+
+            if char.isWhitespace {
+                appendCurrentToken()
+                if tokens.count >= maxTokens {
+                    break
+                }
+            } else {
+                current.append(char)
+            }
+
+            index = next
+        }
+
+        appendCurrentToken()
+
+        let prefix = Array(tokens.prefix(maxTokens))
+        guard !prefix.isEmpty, !looksLikeEnvironmentAssignment(prefix[0]) else {
+            return nil
+        }
+        return prefix
+    }
+
+    private static func looksLikeEnvironmentAssignment(_ token: String) -> Bool {
+        guard let equalsIndex = token.firstIndex(of: "="), equalsIndex != token.startIndex else {
+            return false
+        }
+        let name = token[..<equalsIndex]
+        return name.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+    }
+}

--- a/Tests/CodeIslandTests/AppStatePermissionFlowTests.swift
+++ b/Tests/CodeIslandTests/AppStatePermissionFlowTests.swift
@@ -4,6 +4,21 @@ import CodeIslandCore
 
 @MainActor
 final class AppStatePermissionFlowTests: XCTestCase {
+    private var savedCodexHome: String?
+
+    override func setUp() {
+        super.setUp()
+        savedCodexHome = ProcessInfo.processInfo.environment["CODEX_HOME"]
+    }
+
+    override func tearDown() {
+        if let savedCodexHome {
+            setenv("CODEX_HOME", savedCodexHome, 1)
+        } else {
+            unsetenv("CODEX_HOME")
+        }
+        super.tearDown()
+    }
 
     func testDismissPermissionSkipsAlreadyDismissedSessions() async throws {
         let appState = AppState()
@@ -200,19 +215,91 @@ final class AppStatePermissionFlowTests: XCTestCase {
         XCTAssertNotEqual(first.joined(separator: "|"), second.joined(separator: "|"))
     }
 
+    func testCodexAlwaysAllowPersistsRuleWithoutUnsupportedUpdatedPermissions() async throws {
+        let codexHome = makeTemporaryCodexHome()
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let appState = AppState()
+        let event = try makePermissionRequestEvent(
+            sessionId: "s-codex-always-allow",
+            toolName: "Bash",
+            toolInput: [
+                "command": "php vendor/bin/phpstan analyse $(git diff --name-only origin/master...HEAD | rg '\\.php$' | tr '\\n' ' ' )"
+            ],
+            source: "codex"
+        )
+
+        let responseTask = Task<Data, Never> {
+            await withCheckedContinuation { continuation in
+                appState.handlePermissionRequest(event, continuation: continuation)
+            }
+        }
+
+        await Task.yield()
+        appState.approvePermission(always: true)
+
+        let decision = try extractPermissionDecision(from: await responseTask.value)
+        XCTAssertEqual(decision["behavior"] as? String, "allow")
+        XCTAssertNil(decision["updatedPermissions"])
+
+        let rules = try readCodeIslandRules(in: codexHome)
+        XCTAssertTrue(rules.contains(#"pattern = ["php", "vendor/bin/phpstan", "analyse"]"#))
+        XCTAssertTrue(rules.contains(#"decision = "allow""#))
+    }
+
+    func testCodexAlwaysAllowDoesNotDuplicateExistingCodeIslandRule() throws {
+        let codexHome = makeTemporaryCodexHome()
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let event = try makePermissionRequestEvent(
+            sessionId: "s-codex-dedupe",
+            toolName: "Bash",
+            toolInput: ["command": "npm run build -- --mode production"],
+            source: "codex"
+        )
+
+        let rules = CodexPermissionRules()
+        XCTAssertTrue(rules.persistAlwaysAllowRule(for: event))
+        XCTAssertTrue(rules.persistAlwaysAllowRule(for: event))
+
+        let contents = try readCodeIslandRules(in: codexHome)
+        XCTAssertEqual(contents.components(separatedBy: #"pattern = ["npm", "run", "build"]"#).count - 1, 1)
+    }
+
     // MARK: - Helpers
+
+    private func makeTemporaryCodexHome() -> URL {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        setenv("CODEX_HOME", codexHome.path, 1)
+        return codexHome
+    }
+
+    private func codeIslandRulesPath(in codexHome: URL) -> URL {
+        codexHome
+            .appendingPathComponent("rules", isDirectory: true)
+            .appendingPathComponent("codeisland.rules")
+    }
+
+    private func readCodeIslandRules(in codexHome: URL) throws -> String {
+        try String(contentsOf: codeIslandRulesPath(in: codexHome), encoding: .utf8)
+    }
 
     private func makePermissionRequestEvent(
         sessionId: String,
         toolName: String,
-        toolInput: [String: Any] = ["command": "echo test"]
+        toolInput: [String: Any] = ["command": "echo test"],
+        source: String? = nil
     ) throws -> HookEvent {
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "hook_event_name": "PermissionRequest",
             "session_id": sessionId,
             "tool_name": toolName,
             "tool_input": toolInput
         ]
+        if let source {
+            payload["_source"] = source
+        }
         let data = try JSONSerialization.data(withJSONObject: payload)
         guard let event = HookEvent(from: data) else {
             XCTFail("Failed to parse HookEvent")
@@ -222,10 +309,14 @@ final class AppStatePermissionFlowTests: XCTestCase {
     }
 
     private func extractPermissionBehavior(from responseData: Data) throws -> String {
+        let decision = try extractPermissionDecision(from: responseData)
+        return try XCTUnwrap(decision["behavior"] as? String)
+    }
+
+    private func extractPermissionDecision(from responseData: Data) throws -> [String: Any] {
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: responseData) as? [String: Any])
         let hookSpecificOutput = try XCTUnwrap(json["hookSpecificOutput"] as? [String: Any])
-        let decision = try XCTUnwrap(hookSpecificOutput["decision"] as? [String: Any])
-        return try XCTUnwrap(decision["behavior"] as? String)
+        return try XCTUnwrap(hookSpecificOutput["decision"] as? [String: Any])
     }
 
     private func assertTaskNotResolved(_ task: Task<Data, Never>, timeout: TimeInterval = 0.05) async {


### PR DESCRIPTION
issue: #155

## Summary
- Fix Codex **Always Allow** approvals by persisting a Codex rules entry instead of returning unsupported `updatedPermissions` in the `PermissionRequest` hook response.
- Store CodeIsland-managed allow rules in `$CODEX_HOME/rules/codeisland.rules` (or `~/.codex/rules/codeisland.rules` when `CODEX_HOME` is unset) to keep them separate from the user's default rules file.
- Add regression coverage for the Codex response shape, rules persistence, and duplicate-rule prevention.

## Problem
Codex treats the current permission decision and future auto-approval rules as separate mechanisms. A `PermissionRequest` hook response can allow or deny the current request, but Codex rejects `updatedPermissions` in that response.

Before this change, clicking **Always Allow** in CodeIsland returned a response containing `updatedPermissions`, which caused Codex to fail closed with:

```text
PermissionRequest hook returned unsupported updatedPermissions
```

That meant **Allow Once** worked, but **Always Allow** failed for Codex.

## Solution
For Codex permission requests, CodeIsland now:

1. Persists a `prefix_rule(...)` entry to Codex rules when the user clicks **Always Allow**.
2. Returns the same standard hook response used by **Allow Once**:

```json
{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}
```

Non-Codex providers keep the existing `updatedPermissions` behavior to avoid changing OpenCode / Claude / other CLI semantics.

The new rules helper:

- Detects Codex events via `_source`.
- Uses suggested `prefix_rule` / `prefixRule` data from the payload when available.
- Falls back to a conservative Bash command prefix extraction.
- Stops prefix extraction at shell control structures such as pipes, redirections, command substitutions, separators, and newlines.
- Avoids appending duplicate CodeIsland-managed allow rules.

## Why global `codeisland.rules` for now?
This PR intentionally writes to the global Codex rules layer:

```text
$CODEX_HOME/rules/codeisland.rules
```

rather than project-local rules such as:

```text
<repo>/.codex/rules/default.rules
```

Reasons:

- Codex's built-in allow-list flow currently writes to the global user rules layer by default.
- Project-local `.codex/rules/*` files require the project config layer to be trusted before Codex loads them.
- Writing into a repository's `.codex/` directory from a UI button is a broader behavior change because it modifies project files and can affect git status.
- Using `codeisland.rules` keeps CodeIsland-generated rules separate from `default.rules`, making them easier to audit or clean up while preserving global Codex behavior.

## Open discussion
Should CodeIsland eventually offer project-scoped Always Allow behavior instead?

Possible follow-up options:

- Keep global `codeisland.rules` as the default, matching current Codex behavior.
- Add an explicit project-scoped mode that writes to `<repo>/.codex/rules/codeisland.rules` when the project config layer is trusted.
- Expose separate UI actions such as **Always Allow Globally** and **Always Allow for This Project**.
- Add a CodeIsland settings view for reviewing and deleting CodeIsland-managed rules.

## Test Plan
- [x] `swift test --filter AppStatePermissionFlowTests`
- [x] `swift build`
- [x] Manual end-to-end check: clicking **Always Allow** returns standard `behavior: allow` without `updatedPermissions` and writes the rule to `~/.codex/rules/codeisland.rules`.
