### PR TITLE
feat: 支持灵动岛宽度设置

### DIFF
--- a/Sources/CodeIsland/L10n.swift
+++ b/Sources/CodeIsland/L10n.swift
@@ -456,7 +456,7 @@ final class L10n: ObservableObject {
         "max_visible_sessions": "最大显示会话数",
         "max_visible_sessions_desc": "超出数量的会话将通过滚动查看",
         "collapsed_width_scale": "灵动岛宽度",
-        "collapsed_width_scale_desc": "调整非刘海屏幕上灵动岛的收起宽度",
+        "collapsed_width_scale_desc": "调整灵动岛的收起宽度",
         "notch_height_mode": "顶部高度对齐",
         "notch_height_mode_desc": "让面板与真实 notch 高度、菜单栏高度或自定义值对齐",
         "notch_height_match_notch": "对齐 notch 高度",

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 import CodeIslandCore
 
+enum NotchWidthMetrics {
+    static func effectiveNotchWidth(notchW: CGFloat, collapsedWidthScale: Int) -> CGFloat {
+        let clampedScale = max(50, min(collapsedWidthScale, 150))
+        return notchW * CGFloat(clampedScale) / 100.0
+    }
+}
+
 struct NotchPanelView: View {
     var appState: AppState
     let hasNotch: Bool
@@ -46,11 +53,12 @@ struct NotchPanelView: View {
     /// Minimum wing width needed to display compact bar content
     private var compactWingWidth: CGFloat { mascotSize + 14 }
 
-    /// Effective notch width — applies user scale on non-notch screens (#56).
+    /// Effective island width — applies user scale on both notch and non-notch screens.
     private var effectiveNotchW: CGFloat {
-        guard !hasNotch else { return notchW }
-        let scale = CGFloat(max(collapsedWidthScale, 50)) / 100.0
-        return notchW * scale
+        NotchWidthMetrics.effectiveNotchWidth(
+            notchW: notchW,
+            collapsedWidthScale: collapsedWidthScale
+        )
     }
 
     /// Total panel width — adapts based on state and screen geometry
@@ -58,7 +66,7 @@ struct NotchPanelView: View {
         let nw = effectiveNotchW
         let maxWidth = min(620, screenWidth - 40)
         if showIdleIndicator { return idleHovered ? nw + compactWingWidth * 2 + 80 : nw + compactWingWidth * 2 }
-        if !isActive { return hasNotch ? notchW - 20 : nw }
+        if !isActive { return hasNotch ? nw - 20 : nw }
         if shouldShowExpanded { return min(max(nw + 200, 580), maxWidth) }
         let wing = compactWingWidth
         let extra: CGFloat = appState.status == .idle ? 0 : 20
@@ -75,7 +83,7 @@ struct NotchPanelView: View {
                     HStack(spacing: 0) {
                         CompactLeftWing(appState: appState, expanded: shouldShowExpanded, mascotSize: mascotSize, hasNotch: hasNotch, showToolStatus: showToolStatus)
                         if hasNotch && !shouldShowExpanded {
-                            Spacer(minLength: notchW)
+                            Spacer(minLength: effectiveNotchW)
                         } else if !shouldShowExpanded && showToolStatus {
                             CompactToolStatus(appState: appState)
                             Spacer(minLength: 0)
@@ -89,7 +97,7 @@ struct NotchPanelView: View {
                     IdleIndicatorBar(
                         mascotSize: mascotSize,
                         compactWingWidth: compactWingWidth,
-                        notchW: notchW,
+                        notchW: effectiveNotchW,
                         notchHeight: notchHeight,
                         hasNotch: hasNotch,
                         hovered: idleHovered

--- a/Sources/CodeIsland/Settings.swift
+++ b/Sources/CodeIsland/Settings.swift
@@ -80,7 +80,7 @@ enum SettingsKey {
     // Tool status display
     static let showToolStatus = "showToolStatus"              // true = detailed, false = simple
 
-    // Island collapsed width scale for non-notch screens (percentage: 50–150, default 100)
+    // Island collapsed width scale (percentage: 50–150, default 100)
     static let collapsedWidthScale = "collapsedWidthScale"
 
     // Default mascot source when no sessions exist (falls back to this instead of always "claude")

--- a/Tests/CodeIslandTests/NotchPanelViewTests.swift
+++ b/Tests/CodeIslandTests/NotchPanelViewTests.swift
@@ -2,6 +2,32 @@ import XCTest
 @testable import CodeIsland
 
 final class NotchPanelViewTests: XCTestCase {
+    func testEffectiveNotchWidthAppliesCollapsedWidthScale() {
+        XCTAssertEqual(
+            NotchWidthMetrics.effectiveNotchWidth(notchW: 200, collapsedWidthScale: 50),
+            100,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            NotchWidthMetrics.effectiveNotchWidth(notchW: 200, collapsedWidthScale: 150),
+            300,
+            accuracy: 0.001
+        )
+    }
+
+    func testEffectiveNotchWidthClampsOutOfRangeScale() {
+        XCTAssertEqual(
+            NotchWidthMetrics.effectiveNotchWidth(notchW: 200, collapsedWidthScale: 10),
+            100,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            NotchWidthMetrics.effectiveNotchWidth(notchW: 200, collapsedWidthScale: 250),
+            300,
+            accuracy: 0.001
+        )
+    }
+
     func testShouldTriggerJumpFailureFeedbackWhenAllAttemptsFail() {
         XCTAssertTrue(shouldTriggerJumpFailureFeedback([false, false, false]))
     }


### PR DESCRIPTION
# 变更说明

新增真实刘海屏上的 Dynamic Island 宽度调整支持。

## 背景

原实现中 `collapsedWidthScale` 主要用于非刘海屏：

```swift
guard !hasNotch else { return notchW }
```

因此：

- 非刘海屏会按用户设置调整模拟灵动岛宽度
- 真实刘海屏会保持系统检测到的原始 notch 宽度

本次变更在保留原有非刘海屏行为的基础上，将“Island Width / 灵动岛宽度”扩展为通用设置，使真实刘海屏上的收起态宽度也可以
跟随用户配置变化。

同时，紧凑态和空闲态中部分占位原本使用原始 notchW。为支持真实刘海屏宽度调整，这些内部占位也同步改为使用缩放后的有效宽
度。

## 新增能力

- 真实刘海屏支持通过 collapsedWidthScale 调整 Dynamic Island 收起态宽度
- 非刘海屏继续保留原有模拟灵动岛宽度调整能力
- 紧凑态、空闲态和内部占位统一使用缩放后的有效宽度
- 中文设置说明更新为通用描述
- 增加宽度缩放和边界 clamp 的单元测试

## 验证

- swift test --filter NotchPanelViewTests
- ./build.sh
- lipo -archs .build/dist/CodeIsland.app/Contents/MacOS/CodeIsland

验证结果：

NotchPanelViewTests: 17 tests, 0 failures
CodeIsland.app: x86_64 arm64
codeisland-bridge: x86_64 arm64