### PR TITLE
fix: clean hooks config and adhoc signing

### DIFF
--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -1627,25 +1627,35 @@ struct ConfigInstaller {
             contents = (try? String(contentsOfFile: configPath, encoding: .utf8)) ?? ""
         }
 
-        // Already set to true (non-commented) — don't touch
-        if contents.range(of: #"(?m)^\s*hooks\s*=\s*true"#, options: .regularExpression) != nil {
+        let currentHooksPattern = #"(?m)^\s*hooks\s*=\s*(true|false)\s*(#.*)?$"#
+        let hooksTruePattern = #"(?m)^\s*hooks\s*=\s*true\s*(#.*)?$"#
+        let hooksFalsePattern = #"(?m)^\s*hooks\s*=\s*false\s*(#.*)?$"#
+        let legacyHooksPattern = #"(?m)^\s*codex_hooks\s*=\s*(true|false)\s*(#.*)?$"#
+        let hasCurrentHooks = contents.range(of: currentHooksPattern, options: .regularExpression) != nil
+        let hasLegacyHooks = contents.range(of: legacyHooksPattern, options: .regularExpression) != nil
+
+        // Remove the retired feature name used by older Codex releases. If the
+        // current flag is absent, turn the legacy flag into the current one.
+        if hasLegacyHooks {
+            contents = contents.replacingOccurrences(
+                of: legacyHooksPattern,
+                with: hasCurrentHooks ? "" : "hooks = true",
+                options: .regularExpression
+            )
+        }
+
+        // Already set to true (non-commented) — don't touch beyond legacy cleanup.
+        if contents.range(of: hooksTruePattern, options: .regularExpression) != nil {
+            if hasLegacyHooks {
+                return fm.createFile(atPath: configPath, contents: contents.data(using: .utf8))
+            }
             return true
         }
 
-        // Set to false (non-commented) — flip it to true in place
-        if contents.range(of: #"(?m)^\s*hooks\s*=\s*false"#, options: .regularExpression) != nil {
+        // Set to false (non-commented) — flip it to true in place.
+        if contents.range(of: hooksFalsePattern, options: .regularExpression) != nil {
             contents = contents.replacingOccurrences(
-                of: #"(?m)^\s*hooks\s*=\s*false"#,
-                with: "hooks = true",
-                options: .regularExpression
-            )
-            return fm.createFile(atPath: configPath, contents: contents.data(using: .utf8))
-        }
-
-        // Migrate the retired feature name used by older Codex releases.
-        if contents.range(of: #"(?m)^\s*codex_hooks\s*=\s*(true|false)"#, options: .regularExpression) != nil {
-            contents = contents.replacingOccurrences(
-                of: #"(?m)^\s*codex_hooks\s*=\s*(true|false)"#,
+                of: hooksFalsePattern,
                 with: "hooks = true",
                 options: .regularExpression
             )

--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -529,15 +529,22 @@ def install_claude():
 
 def ensure_toml_codex_hooks(path):
     content = path.read_text() if path.exists() else ""
-    if re.search(r"(?m)^\\s*hooks\\s*=\\s*true\\s*$", content):
+    current_hooks_pattern = r"(?m)^\\s*hooks\\s*=\\s*(true|false)\\s*(#.*)?$"
+    hooks_true_pattern = r"(?m)^\\s*hooks\\s*=\\s*true\\s*(#.*)?$"
+    hooks_false_pattern = r"(?m)^\\s*hooks\\s*=\\s*false\\s*(#.*)?$"
+    legacy_hooks_pattern = r"(?m)^\\s*codex_hooks\\s*=\\s*(true|false)\\s*(#.*)?$"
+    has_current_hooks = re.search(current_hooks_pattern, content) is not None
+    had_legacy_hooks = re.search(legacy_hooks_pattern, content) is not None
+    if re.search(legacy_hooks_pattern, content):
+        replacement = "" if has_current_hooks else "hooks = true"
+        content = re.sub(legacy_hooks_pattern, replacement, content)
+    if re.search(hooks_true_pattern, content):
+        if had_legacy_hooks:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content.rstrip() + "\\n")
         return
-    if re.search(r"(?m)^\\s*hooks\\s*=\\s*false\\s*$", content):
-        content = re.sub(r"(?m)^\\s*hooks\\s*=\\s*false\\s*$", "hooks = true", content)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content.rstrip() + "\\n")
-        return
-    if re.search(r"(?m)^\\s*codex_hooks\\s*=\\s*(true|false)\\s*$", content):
-        content = re.sub(r"(?m)^\\s*codex_hooks\\s*=\\s*(true|false)\\s*$", "hooks = true", content)
+    if re.search(hooks_false_pattern, content):
+        content = re.sub(hooks_false_pattern, "hooks = true", content)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content.rstrip() + "\\n")
         return

--- a/Tests/CodeIslandTests/CodexHomeTests.swift
+++ b/Tests/CodeIslandTests/CodexHomeTests.swift
@@ -99,6 +99,20 @@ final class CodexHomeTests: XCTestCase {
         XCTAssertFalse(contents.contains("codex_hooks"))
     }
 
+    func testEnableCodexHooksConfigRemovesLegacyFeatureNameWhenCurrentFeatureAlreadyEnabled() throws {
+        let codexHome = makeTemporaryCodexHome()
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+        let config = codexHome.appendingPathComponent("config.toml")
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try "[features]\nhooks = true # current\ncodex_hooks = true # legacy\n".write(to: config, atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(ConfigInstaller.enableCodexHooksConfig(fm: .default))
+
+        let contents = try String(contentsOf: config, encoding: .utf8)
+        XCTAssertTrue(contents.contains("hooks = true"))
+        XCTAssertFalse(contents.contains("codex_hooks"))
+    }
+
     private func makeTemporaryCodexHome() -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("codeisland-codex-home-\(UUID().uuidString)", isDirectory: true)

--- a/build.sh
+++ b/build.sh
@@ -142,6 +142,11 @@ build_mac() {
     if [ -z "$SIGN_ID" ]; then
         echo "No developer certificate found, using ad-hoc signing..."
         SIGN_ID="-"
+        ADHOC_ENTITLEMENTS=".build/CodeIsland.adhoc.entitlements"
+        cp "$ENTITLEMENTS" "$ADHOC_ENTITLEMENTS"
+        /usr/libexec/PlistBuddy -c "Set :com.apple.security.cs.disable-library-validation true" "$ADHOC_ENTITLEMENTS" 2>/dev/null || \
+            /usr/libexec/PlistBuddy -c "Add :com.apple.security.cs.disable-library-validation bool true" "$ADHOC_ENTITLEMENTS"
+        ENTITLEMENTS="$ADHOC_ENTITLEMENTS"
     fi
 
     echo "Code signing ($SIGN_ID)..."


### PR DESCRIPTION
## Summary
- 清理旧版 `codex_hooks` 配置项，同时保留/启用当前 `hooks` 配置。
- 同步更新远程安装脚本中的 hooks 配置迁移逻辑。
- ad-hoc 签名时复制 entitlements 并启用 library validation 例外。

## Test Plan
- [x] `swift test --filter CodexHomeTests`
- [x] `git diff --check`
- [ ] `swift test`：失败于既有基线用例 `AppStateCodexSubsessionTests/testCurrentPluginSessionModeHideClearsMergedCodexSubagent`，`origin/main` 同一用例也以 signal 6 失败。