### PR TITLE
fix(AskUserQuestion): always include questions key and use question text as answer key

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -1304,7 +1304,10 @@ final class AppState {
                     header: header
                 )
                 let trimmedHeader = header?.trimmingCharacters(in: .whitespacesAndNewlines)
-                let baseKey = (trimmedHeader?.isEmpty == false ? trimmedHeader : nil) ?? "answer_\(index + 1)"
+                // Claude Code's mapToolResultToToolResultBlockParam looks up answers by
+                // question text: `answers[question.question]`. Using header as the key
+                // causes a mismatch and all answers arrive as empty strings.
+                let baseKey = questionText
                 var answerKey = baseKey
                 if usedAnswerKeys.contains(answerKey) {
                     var suffix = 2
@@ -1481,9 +1484,12 @@ final class AppState {
         originalQuestions: [[String: Any]]?
     ) -> [String: Any] {
         var updatedInput = event.toolInput ?? [:]
-        if let originalQuestions {
-            updatedInput["questions"] = originalQuestions
-        }
+        // `questions` must always be present in updatedInput. Claude Code's
+        // mapToolResultToToolResultBlockParam calls H.map() on it directly;
+        // if the key is absent H is undefined and the call crashes with
+        // "undefined is not an object (evaluating 'H.map')".
+        // Fall back to the raw toolInput value when the [[String:Any]] cast fails.
+        updatedInput["questions"] = originalQuestions ?? (event.toolInput?["questions"] ?? [] as [[String: Any]])
         updatedInput["answers"] = answers
         if let answer {
             updatedInput["answer"] = answer


### PR DESCRIPTION
## Problem

Two bugs in `Sources/CodeIsland/AppState.swift` cause `AskUserQuestion` to fail when used through the CodeIsland hook:

### Bug 1: `H.map undefined` crash

`askUserQuestionUpdatedInput` conditionally set `updatedInput["questions"]` only when the `[[String: Any]]` cast succeeded:

```swift
if let originalQuestions {
    updatedInput["questions"] = originalQuestions
}
```

Claude Code's `mapToolResultToToolResultBlockParam` destructures the hook result as `{questions: H, answers: _, annotations: q}` and immediately calls `H.map()`. If the `questions` key is absent, `H` is `undefined` and the call throws:

> `undefined is not an object (evaluating 'H.map')`

### Bug 2: All answers returned as empty strings

`handleAskUserQuestion` built `answerKey` from the question's `header` field:

```swift
let baseKey = (trimmedHeader?.isEmpty == false ? trimmedHeader : nil) ?? "answer_\(index + 1)"
```

Claude Code looks up answers by question text: `answers[question.question]`. Using the header as the dictionary key means every lookup misses, and all answers come back as empty strings.

## Fix

**Bug 1** — always write the `questions` key, falling back to the raw `toolInput` value when the cast fails:

```swift
updatedInput["questions"] = originalQuestions ?? (event.toolInput?["questions"] ?? [] as [[String: Any]])
```

**Bug 2** — use `questionText` as the answer key to match Claude Code's lookup:

```swift
let baseKey = questionText
```

## Testing

Verified with a 4-option `AskUserQuestion` call containing Chinese text in header/label/description fields. Before the fix: crash or empty answers. After: popup renders correctly and all selected answers are returned to Claude Code.