### PR TITLE
feat: add pi coding-agent integration

### DIFF
--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -120,6 +120,13 @@ struct ConfigInstaller {
     /// Absolute path for external CLI hooks — avoids tilde expansion issues in IDE environments
     private static let bridgeCommand = codeislandDir + "/codeisland-bridge"
     private static let traecliConfigPath = NSHomeDirectory() + "/.trae/traecli.yaml"
+    private static let piAgentDir = NSHomeDirectory() + "/.pi/agent"
+    private static let piExtensionDir = NSHomeDirectory() + "/.pi/agent/extensions"
+    private static let piExtensionPath = NSHomeDirectory() + "/.pi/agent/extensions/codeisland.ts"
+    private static let ompAgentDir = NSHomeDirectory() + "/.omp/agent"
+    private static let ompExtensionDir = NSHomeDirectory() + "/.omp/agent/extensions"
+    private static let ompExtensionPath = NSHomeDirectory() + "/.omp/agent/extensions/codeisland.ts"
+
 
     // Legacy paths for migration cleanup (#32)
     private static let legacyBridgePath = NSHomeDirectory() + "/.claude/hooks/codeisland-bridge"
@@ -368,6 +375,25 @@ struct ConfigInstaller {
                 ("PreCompact",       5, true),
             ]
         ),
+        // pi — TypeScript extension auto-discovered from ~/.pi/agent/extensions.
+        CLIConfig(
+            name: "pi",
+            source: "pi",
+            configPath: ".pi/agent/extensions/codeisland.ts",
+            configKey: "",
+            format: .none,
+            events: []
+        )
+        ,
+        // Oh My Pi / OMP — TypeScript extension loaded from ~/.omp/agent/extensions.
+        CLIConfig(
+            name: "Oh My Pi",
+            source: "omp",
+            configPath: ".omp/agent/extensions/codeisland.ts",
+            configKey: "",
+            format: .none,
+            events: []
+        )
     ]
 
     static var allCLIs: [CLIConfig] {
@@ -613,6 +639,8 @@ struct ConfigInstaller {
                 if !installClaudeHooks(cli: cli, fm: fm) { ok = false }
             } else if cli.source == "traecli" {
                 if !installTraecliHooks(fm: fm) { ok = false }
+            } else if cli.source == "pi" || cli.source == "omp" {
+                continue
             } else {
                 if !installExternalHooks(cli: cli, fm: fm) { ok = false }
             }
@@ -629,6 +657,16 @@ struct ConfigInstaller {
             if !installOpencodePlugin(fm: fm) { ok = false }
         }
 
+        // Install pi extension
+        if isEnabled(source: "pi") {
+            if !installPiExtension(fm: fm) { ok = false }
+        }
+
+        // Install Oh My Pi / OMP extension
+        if isEnabled(source: "omp") {
+            if !installOmpExtension(fm: fm) { ok = false }
+        }
+
         return ok
     }
 
@@ -643,6 +681,10 @@ struct ConfigInstaller {
         for cli in allCLIs {
             if cli.source == "traecli" {
                 uninstallTraecliHooks(fm: fm)
+            } else if cli.source == "pi" {
+                uninstallPiExtension(fm: fm)
+            } else if cli.source == "omp" {
+                uninstallOmpExtension(fm: fm)
             } else {
                 uninstallHooks(cli: cli, fm: fm)
             }
@@ -661,6 +703,8 @@ struct ConfigInstaller {
     /// Check if a specific CLI's hooks are installed
     static func isInstalled(source: String) -> Bool {
         if source == "opencode" { return isOpencodePluginInstalled(fm: FileManager.default) }
+        if source == "pi" { return isPiExtensionInstalled(fm: FileManager.default) }
+        if source == "omp" { return isOmpExtensionInstalled(fm: FileManager.default) }
         if source == "traecli" { return isTraecliHooksInstalled(fm: FileManager.default) }
         if source == "cline" {
             guard let cli = allCLIs.first(where: { $0.source == "cline" }) else { return false }
@@ -673,6 +717,8 @@ struct ConfigInstaller {
     /// Check if CLI directory exists (tool is installed on this machine)
     static func cliExists(source: String) -> Bool {
         if source == "opencode" { return FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.config/opencode") }
+        if source == "pi" { return FileManager.default.fileExists(atPath: piAgentDir) }
+        if source == "omp" { return FileManager.default.fileExists(atPath: ompAgentDir) }
         if source == "copilot" { return FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.copilot") }
         if source == "cline" {
             let fm = FileManager.default
@@ -704,6 +750,12 @@ struct ConfigInstaller {
             if source == "opencode" {
                 return installOpencodePlugin(fm: fm)
             }
+            if source == "pi" {
+                return installPiExtension(fm: fm)
+            }
+            if source == "omp" {
+                return installOmpExtension(fm: fm)
+            }
             guard let cli = allCLIs.first(where: { $0.source == source }) else { return false }
             if cli.source == "claude" {
                 return installClaudeHooks(cli: cli, fm: fm)
@@ -717,6 +769,10 @@ struct ConfigInstaller {
         } else {
             if source == "opencode" {
                 uninstallOpencodePlugin(fm: fm)
+            } else if source == "pi" {
+                uninstallPiExtension(fm: fm)
+            } else if source == "omp" {
+                uninstallOmpExtension(fm: fm)
             } else if let cli = allCLIs.first(where: { $0.source == source }) {
                 if cli.source == "traecli" {
                     uninstallTraecliHooks(fm: fm)
@@ -738,13 +794,34 @@ struct ConfigInstaller {
         var repaired: [String] = []
         for cli in allCLIs {
             guard isEnabled(source: cli.source) else { continue }
-            let dirExists = cli.format == .copilot
-                ? fm.fileExists(atPath: NSHomeDirectory() + "/.copilot")
-                : fm.fileExists(atPath: cli.dirPath)
+            let dirExists: Bool
+            if cli.format == .copilot {
+                dirExists = fm.fileExists(atPath: NSHomeDirectory() + "/.copilot")
+            } else if cli.source == "pi" {
+                dirExists = fm.fileExists(atPath: piAgentDir)
+            } else if cli.source == "omp" {
+                dirExists = fm.fileExists(atPath: ompAgentDir)
+            } else {
+                dirExists = fm.fileExists(atPath: cli.dirPath)
+            }
             guard dirExists else { continue }
             if cli.source == "traecli" {
                 if isTraecliHooksInstalled(fm: fm) { continue }
                 if installTraecliHooks(fm: fm) {
+                    repaired.append(cli.name)
+                }
+                continue
+            }
+            if cli.source == "pi" {
+                if isPiExtensionInstalled(fm: fm) { continue }
+                if installPiExtension(fm: fm) {
+                    repaired.append(cli.name)
+                }
+                continue
+            }
+            if cli.source == "omp" {
+                if isOmpExtensionInstalled(fm: fm) { continue }
+                if installOmpExtension(fm: fm) {
                     repaired.append(cli.name)
                 }
                 continue
@@ -776,6 +853,18 @@ struct ConfigInstaller {
            fm.fileExists(atPath: (opencodeConfigPath as NSString).deletingLastPathComponent),
            !isOpencodePluginInstalled(fm: fm) {
             if installOpencodePlugin(fm: fm) { repaired.append("OpenCode") }
+        }
+        // pi extension
+        if isEnabled(source: "pi"),
+           fm.fileExists(atPath: piAgentDir),
+           !isPiExtensionInstalled(fm: fm) {
+            if installPiExtension(fm: fm) { repaired.append("pi") }
+        }
+        // Oh My Pi / OMP extension
+        if isEnabled(source: "omp"),
+           fm.fileExists(atPath: ompAgentDir),
+           !isOmpExtensionInstalled(fm: fm) {
+            if installOmpExtension(fm: fm) { repaired.append("Oh My Pi") }
         }
         return repaired
     }
@@ -2064,6 +2153,93 @@ struct ConfigInstaller {
         if let url = Bundle.appModule.url(forResource: "codeisland-opencode", withExtension: "js"),
            let src = try? String(contentsOf: url) { return src }
         return nil
+    }
+
+    // MARK: - pi Extension
+
+    /// Current pi extension version — bump when codeisland-pi.ts changes.
+    private static let piExtensionVersion = "v1"
+
+    private static func piExtensionSource() -> String? {
+        if let url = Bundle.appModule.url(forResource: "codeisland-pi", withExtension: "ts", subdirectory: "Resources"),
+           let src = try? String(contentsOf: url) { return src }
+        if let url = Bundle.appModule.url(forResource: "codeisland-pi", withExtension: "ts"),
+           let src = try? String(contentsOf: url) { return src }
+        return nil
+    }
+
+    @discardableResult
+    static func installPiExtension(
+        piAgentDir: String = piAgentDir,
+        piExtensionDir: String = piExtensionDir,
+        piExtensionPath: String = piExtensionPath,
+        fm: FileManager
+    ) -> Bool {
+        guard fm.fileExists(atPath: piAgentDir) else { return true }
+        guard let source = piExtensionSource() else { return false }
+        try? fm.createDirectory(atPath: piExtensionDir, withIntermediateDirectories: true)
+        if fm.fileExists(atPath: piExtensionPath) { try? fm.removeItem(atPath: piExtensionPath) }
+        return fm.createFile(atPath: piExtensionPath, contents: Data(source.utf8))
+    }
+
+    static func uninstallPiExtension(
+        piExtensionPath: String = piExtensionPath,
+        fm: FileManager
+    ) {
+        guard fm.fileExists(atPath: piExtensionPath),
+              let data = fm.contents(atPath: piExtensionPath),
+              let content = String(data: data, encoding: .utf8),
+              content.contains("CodeIsland pi extension")
+        else { return }
+        try? fm.removeItem(atPath: piExtensionPath)
+    }
+
+    static func isPiExtensionInstalled(
+        piExtensionPath: String = piExtensionPath,
+        fm: FileManager
+    ) -> Bool {
+        guard fm.fileExists(atPath: piExtensionPath),
+              let data = fm.contents(atPath: piExtensionPath),
+              let content = String(data: data, encoding: .utf8)
+        else { return false }
+        return content.contains("CodeIsland pi extension")
+            && content.contains("// version: \(piExtensionVersion)")
+    }
+
+    private static func ompExtensionSource() -> String? {
+        if let url = Bundle.appModule.url(forResource: "codeisland-omp", withExtension: "ts", subdirectory: "Resources"),
+           let src = try? String(contentsOf: url) { return src }
+        if let url = Bundle.appModule.url(forResource: "codeisland-omp", withExtension: "ts"),
+           let src = try? String(contentsOf: url) { return src }
+        return nil
+    }
+
+    @discardableResult
+    static func installOmpExtension(
+        ompAgentDir: String = ompAgentDir,
+        ompExtensionDir: String = ompExtensionDir,
+        ompExtensionPath: String = ompExtensionPath,
+        fm: FileManager
+    ) -> Bool {
+        guard fm.fileExists(atPath: ompAgentDir) else { return true }
+        guard let source = ompExtensionSource() else { return false }
+        try? fm.createDirectory(atPath: ompExtensionDir, withIntermediateDirectories: true)
+        if fm.fileExists(atPath: ompExtensionPath) { try? fm.removeItem(atPath: ompExtensionPath) }
+        return fm.createFile(atPath: ompExtensionPath, contents: Data(source.utf8))
+    }
+
+    static func uninstallOmpExtension(
+        ompExtensionPath: String = ompExtensionPath,
+        fm: FileManager
+    ) {
+        uninstallPiExtension(piExtensionPath: ompExtensionPath, fm: fm)
+    }
+
+    static func isOmpExtensionInstalled(
+        ompExtensionPath: String = ompExtensionPath,
+        fm: FileManager
+    ) -> Bool {
+        isPiExtensionInstalled(piExtensionPath: ompExtensionPath, fm: fm)
     }
 
     /// Merge our plugin reference into an opencode.json file's contents.

--- a/Sources/CodeIsland/Resources/codeisland-omp.ts
+++ b/Sources/CodeIsland/Resources/codeisland-omp.ts
@@ -1,40 +1,12 @@
 // CodeIsland pi extension
 // version: v1
+// OMP-compatible install
 
 /**
- * @fileoverview CodeIsland Integration Extension.
+ * @fileoverview CodeIsland Integration Extension for Oh My Pi / OMP.
  *
- * Bridges the running pi session to the CodeIsland macOS floating-window app
- * (https://github.com/wxtsky/CodeIsland) by forwarding lifecycle events over
- * the Unix domain socket CodeIsland listens on.
- *
- * Architecture:
- *   pi (this extension)  ──→  /tmp/codeisland-{uid}.sock  ──→  CodeIsland.app
- *
- * The extension is a socket CLIENT — no server is started. If CodeIsland is not
- * running the socket does not exist and all send calls fail silently.
- *
- * Event mapping:
- *   session_start          →  SessionStart
- *   session_shutdown       →  SessionEnd
- *   before_agent_start     →  UserPromptSubmit
- *   tool_call              →  PreToolUse  (or PermissionRequest for dangerous bash)
- *   tool_result            →  PostToolUse
- *   agent_end              →  Stop
- *   session_before_compact →  PreCompact
- *   session_compact        →  PostCompact
- *
- * Permission handling:
- *   Dangerous bash commands (`rm -rf`, `sudo`, `chmod 777`) are intercepted and
- *   sent as a blocking PermissionRequest via the codeisland-bridge binary. The
- *   extension waits for CodeIsland's decision and returns allow/block accordingly.
- *   This replaces the built-in permission-gate.ts when CodeIsland is active.
- *
- * Installation:
- *   Drop this file in ~/.pi/agent/extensions/ — it is auto-discovered.
- *
- * Requirements:
- *   - CodeIsland.app running on the same machine
+ * This is the same socket bridge as codeisland-pi.ts, but imports OMP's
+ * package scope so `omp` can load it from ~/.omp/agent/extensions.
  */
 
 import { execFile, execFileSync } from "node:child_process";
@@ -42,8 +14,7 @@ import { existsSync } from "node:fs";
 import { connect } from "node:net";
 import { homedir } from "node:os";
 import { getuid } from "node:process";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 
 // ── Socket / bridge constants ─────────────────────────────────────────────────
 
@@ -225,7 +196,7 @@ function extractLastAssistantText(
   messages: readonly unknown[],
 ): string {
   const assistants = messages.filter(
-    (m): m is AssistantMessage =>
+    (m): m is { role: "assistant"; content: unknown } =>
       !!m &&
       typeof m === "object" &&
       (m as { role?: string }).role === "assistant",

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -799,4 +799,141 @@ hooks:
         XCTAssertFalse(cleaned.contains("file:///tmp/codeisland.js"))
         XCTAssertFalse(cleaned.contains("\\/"), "No slash escaping")
     }
+    // MARK: - pi extension
+
+    func testInstallPiExtensionWritesBundledExtensionWhenPiAgentDirExists() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let piAgentDir = tempDir.appendingPathComponent(".pi/agent")
+        let piExtensionDir = piAgentDir.appendingPathComponent("extensions")
+        let piExtensionPath = piExtensionDir.appendingPathComponent("codeisland.ts")
+        try fm.createDirectory(at: piAgentDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        XCTAssertTrue(ConfigInstaller.installPiExtension(
+            piAgentDir: piAgentDir.path,
+            piExtensionDir: piExtensionDir.path,
+            piExtensionPath: piExtensionPath.path,
+            fm: fm
+        ))
+
+        let contents = try String(contentsOf: piExtensionPath)
+        XCTAssertTrue(contents.contains("CodeIsland pi extension"))
+        XCTAssertTrue(contents.contains("// version: v1"))
+        XCTAssertTrue(contents.contains("@earendil-works/pi-coding-agent"))
+        XCTAssertTrue(ConfigInstaller.isPiExtensionInstalled(piExtensionPath: piExtensionPath.path, fm: fm))
+    }
+
+    func testInstallPiExtensionSkipsWhenPiAgentDirIsMissing() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let piAgentDir = tempDir.appendingPathComponent(".pi/agent")
+        let piExtensionDir = piAgentDir.appendingPathComponent("extensions")
+        let piExtensionPath = piExtensionDir.appendingPathComponent("codeisland.ts")
+        defer { try? fm.removeItem(at: tempDir) }
+
+        XCTAssertTrue(ConfigInstaller.installPiExtension(
+            piAgentDir: piAgentDir.path,
+            piExtensionDir: piExtensionDir.path,
+            piExtensionPath: piExtensionPath.path,
+            fm: fm
+        ))
+        XCTAssertFalse(fm.fileExists(atPath: piExtensionPath.path))
+    }
+
+    func testUninstallPiExtensionOnlyRemovesCodeIslandExtension() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let piExtensionPath = tempDir.appendingPathComponent("codeisland.ts")
+        let userExtensionPath = tempDir.appendingPathComponent("user.ts")
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+        try "// CodeIsland pi extension\n// version: v1\n".write(to: piExtensionPath, atomically: true, encoding: .utf8)
+        try "// user extension\n".write(to: userExtensionPath, atomically: true, encoding: .utf8)
+
+        ConfigInstaller.uninstallPiExtension(piExtensionPath: piExtensionPath.path, fm: fm)
+
+        XCTAssertFalse(fm.fileExists(atPath: piExtensionPath.path))
+        XCTAssertTrue(fm.fileExists(atPath: userExtensionPath.path))
+    }
+
+    func testUninstallPiExtensionPreservesUserFileAtSamePath() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let piExtensionPath = tempDir.appendingPathComponent("codeisland.ts")
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+        try "// user-managed file\n".write(to: piExtensionPath, atomically: true, encoding: .utf8)
+
+        ConfigInstaller.uninstallPiExtension(piExtensionPath: piExtensionPath.path, fm: fm)
+
+        XCTAssertTrue(fm.fileExists(atPath: piExtensionPath.path))
+        XCTAssertFalse(ConfigInstaller.isPiExtensionInstalled(piExtensionPath: piExtensionPath.path, fm: fm))
+    }
+
+    func testOutdatedPiExtensionRequiresRepair() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let piExtensionPath = tempDir.appendingPathComponent("codeisland.ts")
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+        try "// CodeIsland pi extension\n// version: old\n".write(to: piExtensionPath, atomically: true, encoding: .utf8)
+
+        XCTAssertFalse(ConfigInstaller.isPiExtensionInstalled(piExtensionPath: piExtensionPath.path, fm: fm))
+    }
+
+    func testInstallOmpExtensionWritesBundledExtensionWhenOmpAgentDirExists() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let ompAgentDir = tempDir.appendingPathComponent(".omp/agent")
+        let ompExtensionDir = ompAgentDir.appendingPathComponent("extensions")
+        let ompExtensionPath = ompExtensionDir.appendingPathComponent("codeisland.ts")
+        try fm.createDirectory(at: ompAgentDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        XCTAssertTrue(ConfigInstaller.installOmpExtension(
+            ompAgentDir: ompAgentDir.path,
+            ompExtensionDir: ompExtensionDir.path,
+            ompExtensionPath: ompExtensionPath.path,
+            fm: fm
+        ))
+
+        let contents = try String(contentsOf: ompExtensionPath)
+        XCTAssertTrue(contents.contains("CodeIsland pi extension"))
+        XCTAssertTrue(contents.contains("// version: v1"))
+        XCTAssertTrue(contents.contains("@oh-my-pi/pi-coding-agent"))
+        XCTAssertFalse(contents.contains("@earendil-works/pi-coding-agent"))
+        XCTAssertTrue(ConfigInstaller.isOmpExtensionInstalled(ompExtensionPath: ompExtensionPath.path, fm: fm))
+    }
+
+    func testInstallOmpExtensionSkipsWhenOmpAgentDirIsMissing() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let ompAgentDir = tempDir.appendingPathComponent(".omp/agent")
+        let ompExtensionDir = ompAgentDir.appendingPathComponent("extensions")
+        let ompExtensionPath = ompExtensionDir.appendingPathComponent("codeisland.ts")
+        defer { try? fm.removeItem(at: tempDir) }
+
+        XCTAssertTrue(ConfigInstaller.installOmpExtension(
+            ompAgentDir: ompAgentDir.path,
+            ompExtensionDir: ompExtensionDir.path,
+            ompExtensionPath: ompExtensionPath.path,
+            fm: fm
+        ))
+        XCTAssertFalse(fm.fileExists(atPath: ompExtensionPath.path))
+    }
+
+    func testUninstallOmpExtensionPreservesUserFileAtSamePath() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let ompExtensionPath = tempDir.appendingPathComponent("codeisland.ts")
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+        try "// user-managed file\n".write(to: ompExtensionPath, atomically: true, encoding: .utf8)
+
+        ConfigInstaller.uninstallOmpExtension(ompExtensionPath: ompExtensionPath.path, fm: fm)
+
+        XCTAssertTrue(fm.fileExists(atPath: ompExtensionPath.path))
+        XCTAssertFalse(ConfigInstaller.isOmpExtensionInstalled(ompExtensionPath: ompExtensionPath.path, fm: fm))
+    }
 }


### PR DESCRIPTION
## Summary

Adds first-class support for pi (`@earendil-works/pi-coding-agent`) and Oh My Pi / OMP (`@oh-my-pi/pi-coding-agent`) by installing bundled TypeScript extensions into their global extension directories.

Fixes #196.

## What changed

- Adds pi to the built-in CLI list as a `.none` installer target.
- Adds Oh My Pi / OMP to the built-in CLI list as a `.none` installer target.
- Installs `Sources/CodeIsland/Resources/codeisland-pi.ts` to `~/.pi/agent/extensions/codeisland.ts` when `~/.pi/agent` exists.
- Installs `Sources/CodeIsland/Resources/codeisland-omp.ts` to `~/.omp/agent/extensions/codeisland.ts` when `~/.omp/agent` exists.
- Wires pi and OMP status, enable/disable, uninstall, and repair paths through `ConfigInstaller`.
- Updates the pi extension to current package names:
  - `@earendil-works/pi-coding-agent`
  - `@earendil-works/pi-ai`
- Adds an OMP-specific extension using:
  - `@oh-my-pi/pi-coding-agent`
- Tags the extensions with a version marker so repair can detect stale installs.
- Uses `session_title` for completion events, matching CodeIsland's session title metadata field.
- Adds installer tests for install, missing agent dir no-op, uninstall safety, and stale-version detection.

## Verification

- `swift test --filter ConfigInstallerTests`
- Typechecked `codeisland-pi.ts` against a local `@earendil-works/pi-coding-agent` checkout.
- Typechecked `codeisland-omp.ts` against a local `@oh-my-pi/pi-coding-agent` install.
- Locally smoke-tested `omp-pi -e ~/.omp/agent/extensions/codeisland.ts ...` and verified CodeIsland recorded a live `source: "pi"` session with Ghostty terminal metadata.

