### PR TITLE
fix(remote): per-user SSH socket isolation + tunnel/iTerm2 jump hardening (#193, #190, #198)

### DIFF
--- a/Sources/CodeIsland/RemoteHost.swift
+++ b/Sources/CodeIsland/RemoteHost.swift
@@ -54,6 +54,9 @@ struct RemoteHost: Identifiable, Codable, Equatable, Sendable {
         return "\(trimmedUser)@\(host.trimmingCharacters(in: .whitespacesAndNewlines))"
     }
 
+    /// Legacy shared fallback socket path. The live per-user path is resolved at
+    /// connect time via `RemoteInstaller.prepareRemoteSocketPath` (#193); this value
+    /// is only used when probing the remote UID fails.
     var remoteSocketPath: String { "/tmp/codeisland.sock" }
 
     var displayAddress: String {

--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -17,7 +17,7 @@ enum RemoteInstaller {
     private static let remoteHookVersion = "0.1.2"
     private static let remoteOpencodePluginVersion = "v2"
 
-    static func installAll(host: RemoteHost) async -> RemoteInstallResult {
+    static func installAll(host: RemoteHost, remoteSocketPath: String) async -> RemoteInstallResult {
         guard let source = remoteHookSource() else {
             return RemoteInstallResult(ok: false, message: "Missing remote hook resource")
         }
@@ -30,12 +30,12 @@ enum RemoteInstaller {
             return RemoteInstallResult(ok: false, message: "Upload failed: \(upload.stderrSummary)")
         }
 
-        let uploadOpencode = await uploadRemoteOpencodePlugin(source: opencodePlugin, host: host)
+        let uploadOpencode = await uploadRemoteOpencodePlugin(source: opencodePlugin, host: host, remoteSocketPath: remoteSocketPath)
         guard uploadOpencode.ok else {
             return RemoteInstallResult(ok: false, message: "OpenCode plugin upload failed: \(uploadOpencode.stderrSummary)")
         }
 
-        let configure = await configureRemoteHooks(host: host)
+        let configure = await configureRemoteHooks(host: host, remoteSocketPath: remoteSocketPath)
         guard configure.ok else {
             return RemoteInstallResult(ok: false, message: "Install failed: \(configure.stderrSummary)")
         }
@@ -44,8 +44,23 @@ enum RemoteInstaller {
         return RemoteInstallResult(ok: true, message: summary)
     }
 
-    static func cleanupRemoteSocket(host: RemoteHost) async {
+    /// Probe the remote user's UID and return a per-user socket path so that multiple
+    /// OS users on a shared host don't collide on a single `/tmp/codeisland.sock` (#193).
+    /// Also clears any stale per-user socket left behind by a previous session. Falls
+    /// back to the legacy shared path when the probe fails (older / restricted host).
+    static func prepareRemoteSocketPath(host: RemoteHost) async -> String {
+        let probe = await runSSH(
+            host: host,
+            command: "uid=$(id -u 2>/dev/null); rm -f \"/tmp/codeisland-$uid.sock\" 2>/dev/null; printf '%s' \"$uid\"",
+            timeout: 8
+        )
+        let uid = probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if probe.ok, !uid.isEmpty, uid.allSatisfy({ $0.isNumber }) {
+            return "/tmp/codeisland-\(uid).sock"
+        }
+        // Probe failed — fall back to the legacy shared path, clearing any stale socket.
         _ = await runSSH(host: host, command: "rm -f \(shellSingleQuoted(host.remoteSocketPath))", timeout: 8)
+        return host.remoteSocketPath
     }
 
     private static func remoteHookSource() -> String? {
@@ -86,8 +101,8 @@ print(target)
         return await runSSH(host: host, command: "python3 - <<'PY'\n\(py)\nPY", timeout: 25)
     }
 
-    private static func uploadRemoteOpencodePlugin(source: String, host: RemoteHost) async -> RemoteCommandResult {
-        let configuredSource = remoteOpencodePluginForInstall(source: source, host: host)
+    private static func uploadRemoteOpencodePlugin(source: String, host: RemoteHost, remoteSocketPath: String) async -> RemoteCommandResult {
+        let configuredSource = remoteOpencodePluginForInstall(source: source, host: host, remoteSocketPath: remoteSocketPath)
         let encoded = Data(configuredSource.utf8).base64EncodedString()
         let py = """
 import base64, os, pathlib
@@ -101,8 +116,8 @@ print(target)
         return await runSSH(host: host, command: "python3 - <<'PY'\n\(py)\nPY", timeout: 25)
     }
 
-    private static func configureRemoteHooks(host: RemoteHost) async -> RemoteCommandResult {
-        let py = configureRemoteHooksScript(host: host)
+    private static func configureRemoteHooks(host: RemoteHost, remoteSocketPath: String) async -> RemoteCommandResult {
+        let py = configureRemoteHooksScript(host: host, remoteSocketPath: remoteSocketPath)
         // Run via the remote user's login shell so ~/.zprofile / ~/.bash_profile etc. are
         // sourced — that's how $CODEX_HOME (and similar) reach a non-interactive ssh session.
         // base64 keeps the script intact regardless of shell quoting.
@@ -112,11 +127,12 @@ print(target)
         return await runSSH(host: host, command: command, timeout: 30)
     }
 
-    static func configureRemoteHooksScript(host: RemoteHost) -> String {
+    static func configureRemoteHooksScript(host: RemoteHost, remoteSocketPath: String? = nil) -> String {
         let hostId = pythonStringLiteral(host.id)
         let hostName = pythonStringLiteral(host.name)
         let version = pythonStringLiteral(remoteHookVersion)
         let opencodePluginVersion = pythonStringLiteral(remoteOpencodePluginVersion)
+        let socketPath = pythonStringLiteral(remoteSocketPath ?? host.remoteSocketPath)
         return """
 import json
 import pathlib
@@ -130,6 +146,7 @@ host_id = \(hostId)
 host_name = \(hostName)
 version = \(version)
 opencode_plugin_version = \(opencodePluginVersion)
+socket_path = \(socketPath)
 
 def _codex_home():
     raw = (os.environ.get("CODEX_HOME") or "").strip()
@@ -207,7 +224,7 @@ def write_opencode_config(path, data):
     write_json(path, data)
 
 def command_for(source):
-    return f"CODEISLAND_SOCKET_PATH=/tmp/codeisland.sock CODEISLAND_REMOTE_HOST_ID={json.dumps(host_id)} CODEISLAND_REMOTE_HOST_NAME={json.dumps(host_name)} CODEISLAND_SOURCE={source} python3 ~/.codeisland/codeisland-remote-hook.py"
+    return f"CODEISLAND_SOCKET_PATH={socket_path} CODEISLAND_REMOTE_HOST_ID={json.dumps(host_id)} CODEISLAND_REMOTE_HOST_NAME={json.dumps(host_name)} CODEISLAND_SOURCE={source} python3 ~/.codeisland/codeisland-remote-hook.py"
 
 def remove_our_hooks(hooks):
     for event in list(hooks.keys()):
@@ -768,11 +785,12 @@ print(" · ".join(parts))
         return "\"\(escaped)\""
     }
 
-    static func remoteOpencodePluginForInstall(source: String, host: RemoteHost) -> String {
-        source
+    static func remoteOpencodePluginForInstall(source: String, host: RemoteHost, remoteSocketPath: String? = nil) -> String {
+        let socketPath = remoteSocketPath ?? host.remoteSocketPath
+        return source
             .replacingOccurrences(
                 of: #"const SOCKET_PATH = process.env.CODEISLAND_SOCKET_PATH || "/tmp/codeisland.sock";"#,
-                with: #"const SOCKET_PATH = \#(jsonStringLiteral(host.remoteSocketPath));"#
+                with: #"const SOCKET_PATH = \#(jsonStringLiteral(socketPath));"#
             )
             .replacingOccurrences(
                 of: #"const REMOTE_HOST_ID = process.env.CODEISLAND_REMOTE_HOST_ID || "";"#,

--- a/Sources/CodeIsland/RemoteManager.swift
+++ b/Sources/CodeIsland/RemoteManager.swift
@@ -12,6 +12,9 @@ final class RemoteManager: ObservableObject {
     var onDisconnect: ((String) -> Void)?
 
     private var forwarders: [String: SSHForwarder] = [:]
+    // Per-user remote socket path resolved at connect time (#193). Keyed by host id;
+    // reused by installHooks so the SSH -R forward and the remote hooks agree.
+    private var remoteSocketPaths: [String: String] = [:]
     private let defaults = UserDefaults.standard
     private let hostsKey = "remoteHosts"
 
@@ -105,9 +108,10 @@ final class RemoteManager: ObservableObject {
         lastMessage[id] = host.displayAddress
 
         Task {
-            await RemoteInstaller.cleanupRemoteSocket(host: host)
+            let remoteSocketPath = await RemoteInstaller.prepareRemoteSocketPath(host: host)
             await MainActor.run {
-                forwarder.connect(host: host, localSocketPath: HookServer.socketPath)
+                self.remoteSocketPaths[host.id] = remoteSocketPath
+                forwarder.connect(host: host, localSocketPath: HookServer.socketPath, remoteSocketPath: remoteSocketPath)
             }
         }
     }
@@ -117,6 +121,7 @@ final class RemoteManager: ObservableObject {
         reconnectAttempts[id] = nil
         forwarders[id]?.disconnect()
         forwarders[id] = nil
+        remoteSocketPaths[id] = nil
         connectionStatus[id] = .disconnected
         installRunning[id] = false
         onDisconnect?(id)
@@ -182,7 +187,8 @@ final class RemoteManager: ObservableObject {
 
     private func installHooks(for host: RemoteHost) async {
         installRunning[host.id] = true
-        let result = await RemoteInstaller.installAll(host: host)
+        let remoteSocketPath = remoteSocketPaths[host.id] ?? host.remoteSocketPath
+        let result = await RemoteInstaller.installAll(host: host, remoteSocketPath: remoteSocketPath)
         installRunning[host.id] = false
         lastMessage[host.id] = result.message
         if !result.ok {

--- a/Sources/CodeIsland/Resources/codeisland-remote-hook.py
+++ b/Sources/CodeIsland/Resources/codeisland-remote-hook.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 
 VERSION = "0.1.2"
-SOCKET_PATH = os.environ.get("CODEISLAND_SOCKET_PATH", "/tmp/codeisland.sock")
+# Per-user socket path (#193): CodeIsland injects CODEISLAND_SOCKET_PATH via the hook
+# command, but fall back to a uid-scoped path so multiple users on a shared host never
+# collide on a single /tmp/codeisland.sock.
+SOCKET_PATH = os.environ.get("CODEISLAND_SOCKET_PATH") or f"/tmp/codeisland-{os.getuid()}.sock"
 REMOTE_HOST_ID = os.environ.get("CODEISLAND_REMOTE_HOST_ID", "")
 REMOTE_HOST_NAME = os.environ.get("CODEISLAND_REMOTE_HOST_NAME", "")
 SOURCE = os.environ.get("CODEISLAND_SOURCE", "")

--- a/Sources/CodeIsland/SSHForwarder.swift
+++ b/Sources/CodeIsland/SSHForwarder.swift
@@ -22,7 +22,7 @@ final class SSHForwarder {
     private var stderrPipe: Pipe?
     private var generation: UInt64 = 0
 
-    func connect(host: RemoteHost, localSocketPath: String) {
+    func connect(host: RemoteHost, localSocketPath: String, remoteSocketPath: String) {
         disconnect()
 
         let target = host.sshTarget
@@ -37,7 +37,7 @@ final class SSHForwarder {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-        process.arguments = buildArguments(host: host, localSocketPath: localSocketPath)
+        process.arguments = buildArguments(host: host, localSocketPath: localSocketPath, remoteSocketPath: remoteSocketPath)
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.environment = buildEnvironment(host: host)
@@ -99,7 +99,7 @@ final class SSHForwarder {
         self.process = nil
     }
 
-    private func buildArguments(host: RemoteHost, localSocketPath: String) -> [String] {
+    private func buildArguments(host: RemoteHost, localSocketPath: String, remoteSocketPath: String) -> [String] {
         var args: [String] = [
             "-N",
             "-T",
@@ -109,6 +109,12 @@ final class SSHForwarder {
             "-o", "ServerAliveCountMax=2",
             "-o", "StreamLocalBindUnlink=yes",
             "-o", "StreamLocalBindMask=0000",
+            // Never reuse or spawn a multiplexing master connection (#190): a shared
+            // ControlMaster makes `ssh -N` hand the forward to the master and exit 0
+            // immediately, which we'd misread as a failed tunnel. Force a dedicated
+            // connection that stays alive for the lifetime of this forwarder.
+            "-o", "ControlMaster=no",
+            "-o", "ControlPath=none",
         ]
 
         if let port = host.port {
@@ -120,7 +126,7 @@ final class SSHForwarder {
             args += ["-i", trimmedIdentity]
         }
 
-        args += ["-R", "\(host.remoteSocketPath):\(localSocketPath)"]
+        args += ["-R", "\(remoteSocketPath):\(localSocketPath)"]
         args.append(host.sshTarget)
         return args
     }

--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -482,6 +482,7 @@ struct TerminalActivator {
                             repeat with s in sessions of t
                                 try
                                     if tty of s is "\(escapeAppleScript(fullTty))" then
+                                        select w
                                         select t
                                         select s
                                         set index of w to 1
@@ -508,6 +509,7 @@ struct TerminalActivator {
                         repeat with s in sessions of t
                             try
                                 if name of s contains "\(escapeAppleScript(dirName))" or path of s contains "\(escapeAppleScript(dirName))" then
+                                    select w
                                     select t
                                     select s
                                     set index of w to 1
@@ -541,6 +543,7 @@ struct TerminalActivator {
                         repeat with aSession in sessions of aTab
                             if unique ID of aSession is "\(escapeAppleScript(sessionId))" then
                                 set miniaturized of aWindow to false
+                                select aWindow
                                 select aTab
                                 select aSession
                                 return

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -517,6 +517,37 @@ hooks:
         XCTAssertTrue(plugin.contains(#"const REMOTE_HOST_NAME = "devbox\nwest";"#))
     }
 
+    func testRemoteInstallerConfigureScriptInjectsPerUserSocketPath() {
+        // #193: on a shared remote host the hook command must point at a uid-scoped
+        // socket path so different OS users don't collide on /tmp/codeisland.sock.
+        let host = RemoteHost(id: "host-1", name: "devbox", host: "example.com")
+
+        let script = RemoteInstaller.configureRemoteHooksScript(host: host, remoteSocketPath: "/tmp/codeisland-1000.sock")
+
+        XCTAssertTrue(script.contains(#"socket_path = "/tmp/codeisland-1000.sock""#))
+        XCTAssertTrue(script.contains("CODEISLAND_SOCKET_PATH={socket_path}"))
+        XCTAssertFalse(script.contains("CODEISLAND_SOCKET_PATH=/tmp/codeisland.sock"))
+    }
+
+    func testRemoteInstallerConfigureScriptFallsBackToLegacySocketPath() {
+        // When no per-user path is supplied (probe failed) the legacy shared path is used.
+        let host = RemoteHost(id: "host-1", name: "devbox", host: "example.com")
+
+        let script = RemoteInstaller.configureRemoteHooksScript(host: host)
+
+        XCTAssertTrue(script.contains(#"socket_path = "/tmp/codeisland.sock""#))
+    }
+
+    func testRemoteOpencodePluginInjectsPerUserSocketPath() {
+        // #193
+        let host = RemoteHost(id: "host-1", name: "devbox", host: "example.com")
+        let source = #"const SOCKET_PATH = process.env.CODEISLAND_SOCKET_PATH || "/tmp/codeisland.sock";"#
+
+        let plugin = RemoteInstaller.remoteOpencodePluginForInstall(source: source, host: host, remoteSocketPath: "/tmp/codeisland-1000.sock")
+
+        XCTAssertTrue(plugin.contains(#"const SOCKET_PATH = "/tmp/codeisland-1000.sock";"#))
+    }
+
     func testRemoteTraecliPermissionRequestRoutesAsPermissionAndUsesRemoteSessionNamespace() async throws {
         let payload: [String: Any] = [
             "hook_event_name": "permission_request",


### PR DESCRIPTION
## Summary

Fixes three remote/jump robustness issues reported on the tracker.

### #193 — Remote SSH socket shared across users on multi-user hosts
`RemoteHost.remoteSocketPath` was hardcoded to `/tmp/codeisland.sock`, while the local app already uses `/tmp/codeisland-<uid>.sock`. On a shared remote host, with `StreamLocalBindUnlink=yes`, a second user's reverse forward would unlink/rebind the first user's socket, so their Claude/Codex/OpenCode hooks silently sent events to the wrong tunnel (or failed).

Fix: probe the remote uid once at connect time and route a per-user `/tmp/codeisland-<uid>.sock` consistently through:
- the SSH `-R` reverse forward (`SSHForwarder`)
- the remote hook command env `CODEISLAND_SOCKET_PATH` (`command_for` in `configureRemoteHooksScript`)
- the OpenCode remote plugin (`remoteOpencodePluginForInstall`)
- the remote hook script default (`codeisland-remote-hook.py` now defaults to a uid-scoped path)

If the uid probe fails (older/restricted host), we fall back to the legacy shared path, so nothing regresses. `RemoteManager` resolves the path before opening the tunnel and reuses it for hook installation.

### #190 — `ssh exited (0)`, connection reported as failed
The forwarder uses `ssh -N`. If the user's SSH config enables connection multiplexing (`ControlMaster auto` + `ControlPath`), `ssh -N` can hand the forward to a pre-existing master and **exit 0 immediately** — which the forwarder misread as a dead tunnel (matches the reporter: manual `ssh` works, CodeIsland shows "ssh exited (0)"). Force `ControlMaster=no` / `ControlPath=none` so the tunnel always holds its own dedicated connection.

### #198 — iTerm2 fullscreen / cross-Space jump lands on the wrong window
The session-id jump path selected the matched tab + session but never selected the **window**, so a fullscreen window (its own Space) wasn't raised. Add `select <window>` on all three iTerm2 match paths (session-id, tty, cwd) so the owning window is brought to the front and macOS switches to its Space.

## Tests
- `swift test` — 333 passing.
- New: per-user socket path injection into the remote hook script and OpenCode plugin, plus the legacy-fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)