### PR TITLE
fix(remote): harden iTerm2 window select + remote uid probe (follow-up to #201)

### DIFF
--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -46,20 +46,20 @@ enum RemoteInstaller {
 
     /// Probe the remote user's UID and return a per-user socket path so that multiple
     /// OS users on a shared host don't collide on a single `/tmp/codeisland.sock` (#193).
-    /// Also clears any stale per-user socket left behind by a previous session. Falls
-    /// back to the legacy shared path when the probe fails (older / restricted host).
+    /// Falls back to the legacy shared path when the probe fails (older / restricted host).
     static func prepareRemoteSocketPath(host: RemoteHost) async -> String {
-        let probe = await runSSH(
-            host: host,
-            command: "uid=$(id -u 2>/dev/null); rm -f \"/tmp/codeisland-$uid.sock\" 2>/dev/null; printf '%s' \"$uid\"",
-            timeout: 8
-        )
+        // `id -u` is a bare external command, so it returns the remote uid identically
+        // under any login shell (bash / zsh / fish / csh). A fancier `$(...)` pipeline
+        // would break under non-POSIX login shells like fish and silently fall back.
+        let probe = await runSSH(host: host, command: "id -u", timeout: 8)
         let uid = probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         if probe.ok, !uid.isEmpty, uid.allSatisfy({ $0.isNumber }) {
             return "/tmp/codeisland-\(uid).sock"
         }
-        // Probe failed — fall back to the legacy shared path, clearing any stale socket.
-        _ = await runSSH(host: host, command: "rm -f \(shellSingleQuoted(host.remoteSocketPath))", timeout: 8)
+        // Probe failed (old / restricted host) — fall back to the legacy shared path.
+        // StreamLocalBindUnlink=yes on the forward already clears any stale socket, so
+        // we avoid a second SSH round-trip here (it would just add latency on a host
+        // that's likely failing to connect anyway).
         return host.remoteSocketPath
     }
 
@@ -820,10 +820,6 @@ print(" · ".join(parts))
             }
         }
         return "\"\(escaped)\""
-    }
-
-    private static func shellSingleQuoted(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }
 

--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -482,7 +482,9 @@ struct TerminalActivator {
                             repeat with s in sessions of t
                                 try
                                     if tty of s is "\(escapeAppleScript(fullTty))" then
-                                        select w
+                                        try
+                                            select w
+                                        end try
                                         select t
                                         select s
                                         set index of w to 1
@@ -509,7 +511,9 @@ struct TerminalActivator {
                         repeat with s in sessions of t
                             try
                                 if name of s contains "\(escapeAppleScript(dirName))" or path of s contains "\(escapeAppleScript(dirName))" then
-                                    select w
+                                    try
+                                        select w
+                                    end try
                                     select t
                                     select s
                                     set index of w to 1
@@ -543,7 +547,9 @@ struct TerminalActivator {
                         repeat with aSession in sessions of aTab
                             if unique ID of aSession is "\(escapeAppleScript(sessionId))" then
                                 set miniaturized of aWindow to false
-                                select aWindow
+                                try
+                                    select aWindow
+                                end try
                                 select aTab
                                 select aSession
                                 return


### PR DESCRIPTION
Self-review follow-up on #201.

### 1. iTerm2 `select <window>` could abort the jump
#201 added `select <window>` to raise the matched window on fullscreen / cross-Space jumps. iTerm2 does support `select` on a window, but if it ever throws (window mid-transition, etc.) the surrounding `try` would swallow it and skip the `select tab` / `select session` that follow — i.e. the jump would do *nothing*, worse than before #201. Each `select <window>` is now wrapped in its own `try` on all three match paths (session-id / tty / cwd).

### 2. Remote uid probe used a non-POSIX pipeline
The probe ran `uid=$(id -u ...); rm -f ...; printf ...`. SSH runs remote commands under the user's **login shell**, so on a `fish`/`csh` login shell the `$(...)` form fails and we silently fall back to the shared socket path (defeating #193 for those users). Replaced with a bare `id -u`, which behaves identically under any shell. Also removed the redundant stale-socket cleanup (the forward's `StreamLocalBindUnlink=yes` already handles it), so a host that's failing to connect no longer eats a second SSH round-trip.

### 3. Removed the now-unused `shellSingleQuoted` helper.

`swift test` — 341 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)