### PR TITLE
fix(jump): match IDE workspace window by cwd for multi-window apps (#199)

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -70,10 +70,15 @@ struct TerminalActivator {
     static func activate(session: SessionSnapshot, sessionId: String? = nil) {
         guard !session.isRemote else { return }
 
-        // Native app by bundle ID (e.g. Codex APP vs Codex CLI)
+        // Native app by bundle ID (e.g. Codex APP vs Codex CLI). These are IDE-style
+        // apps (Cursor, Trae, Qoder, Factory, …) that can hold several workspace
+        // windows at once, so match the one whose title contains the session's
+        // project folder instead of just raising the most-recently-used window (#199).
+        // activateIDEWindow falls back to a plain app-level activation when there's
+        // no cwd or no matching window, so this never regresses single-window apps.
         if let bundleId = session.termBundleId,
            nativeAppBundles[bundleId] != nil {
-            activateByBundleId(bundleId)
+            activateIDEWindow(bundleId: bundleId, cwd: session.cwd)
             return
         }
 


### PR DESCRIPTION
Fixes #199.

Cursor (and other IDE-style apps: Trae, Qoder, Factory, CodeBuddy, StepFun, OpenCode desktop, WorkBuddy) can hold several workspace windows open at once. When you clicked a session card, the native-app-bundle jump path only did app-level `activate()`, which raises whichever window was most recently used — not the one running the agent you clicked.

The fix routes these through the existing `activateIDEWindow(bundleId:cwd:)`, which `AXRaise`s the window whose title contains the session's project folder. It already falls back to plain app-level activation when there's no cwd or no matching window, so single-window apps (and sessions without a cwd) behave exactly as before — this is strictly additive.

The same window-matching was already used for IDE *integrated terminals*; this just extends it to IDE *agent sources*.

`swift test` — 341 passing. (Window matching itself is AppleScript/AX and not unit-testable; verified the build and that the fallback path is preserved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)