### PR TITLE
feat(remote): install custom CLI hooks on SSH remote hosts (#192)

### DIFF
--- a/Sources/CodeIsland/RemoteInstaller.swift
+++ b/Sources/CodeIsland/RemoteInstaller.swift
@@ -127,12 +127,17 @@ print(target)
         return await runSSH(host: host, command: command, timeout: 30)
     }
 
-    static func configureRemoteHooksScript(host: RemoteHost, remoteSocketPath: String? = nil) -> String {
+    static func configureRemoteHooksScript(
+        host: RemoteHost,
+        remoteSocketPath: String? = nil,
+        customCLIs: [CLIConfig] = ConfigInstaller.customCLIs()
+    ) -> String {
         let hostId = pythonStringLiteral(host.id)
         let hostName = pythonStringLiteral(host.name)
         let version = pythonStringLiteral(remoteHookVersion)
         let opencodePluginVersion = pythonStringLiteral(remoteOpencodePluginVersion)
         let socketPath = pythonStringLiteral(remoteSocketPath ?? host.remoteSocketPath)
+        let customCLIsLiteral = remoteCustomCLIsLiteral(customCLIs)
         return """
 import json
 import pathlib
@@ -147,6 +152,7 @@ host_name = \(hostName)
 version = \(version)
 opencode_plugin_version = \(opencodePluginVersion)
 socket_path = \(socketPath)
+custom_clis = \(customCLIsLiteral)
 
 def _codex_home():
     raw = (os.environ.get("CODEX_HOME") or "").strip()
@@ -712,7 +718,35 @@ def install_opencode():
                 write_opencode_config(legacy_path, legacy)
     return "OpenCode ok"
 
-parts = [install_claude(), install_hermes(), install_codex(), install_codebuddy(), install_traecli(), install_opencode()]
+def install_custom():
+    results = []
+    for cli in custom_clis:
+        source = cli["source"]
+        config_path = home / cli["config_path"]
+        if not config_path.parent.exists() and shutil.which(source) is None:
+            results.append(cli["name"] + " skipped")
+            continue
+        data = ensure_json(config_path)
+        if not isinstance(data, dict):
+            data = {}
+        hooks = data.get(cli["config_key"])
+        if not isinstance(hooks, dict):
+            hooks = {}
+        remove_our_hooks(hooks)
+        cmd = command_for(source)
+        for ev in cli["events"]:
+            event = ev[0]
+            timeout = ev[1]
+            if cli["format"] == "claude":
+                hooks[event] = [{"matcher": "*", "hooks": [{"type": "command", "command": cmd, "timeout": timeout}]}]
+            else:
+                hooks[event] = [{"hooks": [{"type": "command", "command": cmd, "timeout": timeout}]}]
+        data[cli["config_key"]] = hooks
+        write_json(config_path, data)
+        results.append(cli["name"] + " ok")
+    return results
+
+parts = [install_claude(), install_hermes(), install_codex(), install_codebuddy(), install_traecli(), install_opencode()] + install_custom()
 print(" · ".join(parts))
 """
     }
@@ -775,6 +809,29 @@ print(" · ".join(parts))
         }
         args.append(host.sshTarget)
         return args
+    }
+
+    /// Serialize custom CLI configs into a Python list literal for the remote install
+    /// script. Only `.claude` / `.nested` formats are emitted — their stdin carries
+    /// `hook_event_name`, so the remote hook handles them with no `--event` flag.
+    /// Other formats (flat/Cursor, traecli, copilot, kimi, …) are skipped remotely (#192).
+    private static func remoteCustomCLIsLiteral(_ clis: [CLIConfig]) -> String {
+        let supported = clis.filter { $0.format == .claude || $0.format == .nested }
+        let entries = supported.map { cli -> String in
+            let fmt = cli.format == .claude ? "claude" : "nested"
+            let events = cli.events
+                .map { "[\(pythonStringLiteral($0.0)), \($0.1)]" }
+                .joined(separator: ", ")
+            return "{"
+                + "\"name\": \(pythonStringLiteral(cli.name)), "
+                + "\"source\": \(pythonStringLiteral(cli.source)), "
+                + "\"config_path\": \(pythonStringLiteral(cli.configPath)), "
+                + "\"config_key\": \(pythonStringLiteral(cli.configKey)), "
+                + "\"format\": \(pythonStringLiteral(fmt)), "
+                + "\"events\": [\(events)]"
+                + "}"
+        }
+        return "[\(entries.joined(separator: ", "))]"
     }
 
     private static func pythonStringLiteral(_ value: String) -> String {

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -548,6 +548,52 @@ hooks:
         XCTAssertTrue(plugin.contains(#"const SOCKET_PATH = "/tmp/codeisland-1000.sock";"#))
     }
 
+    func testRemoteInstallerConfigureScriptInstallsCustomClaudeCLI() throws {
+        // #192: custom CLIs (claude/nested format) should also get hooks installed on remote hosts.
+        let host = RemoteHost(id: "host-1", name: "devbox", host: "example.com")
+        let custom = CLIConfig(
+            name: "MyCLI", source: "mycli",
+            configPath: ".mycli/settings.json", configKey: "hooks",
+            format: .claude,
+            events: [("UserPromptSubmit", 5, true), ("Stop", 5, true)]
+        )
+
+        let script = RemoteInstaller.configureRemoteHooksScript(host: host, customCLIs: [custom])
+
+        XCTAssertTrue(script.contains("def install_custom():"))
+        XCTAssertTrue(script.contains(#""source": "mycli""#))
+        XCTAssertTrue(script.contains(#""config_path": ".mycli/settings.json""#))
+        XCTAssertTrue(script.contains(#""format": "claude""#))
+        XCTAssertTrue(script.contains("install_opencode()] + install_custom()"))
+        try assertPythonCompiles(script)
+    }
+
+    func testRemoteInstallerConfigureScriptSkipsUnsupportedCustomFormat() {
+        // #192: flat (Cursor-style) hooks need a --event flag the remote hook can't
+        // supply, so they are skipped remotely — the list must come out empty.
+        let host = RemoteHost(id: "host-1", name: "devbox", host: "example.com")
+        let flat = CLIConfig(
+            name: "CursorLike", source: "cursorlike",
+            configPath: ".cl/settings.json", configKey: "hooks",
+            format: .flat,
+            events: [("beforeSubmitPrompt", 5, false)]
+        )
+
+        let script = RemoteInstaller.configureRemoteHooksScript(host: host, customCLIs: [flat])
+
+        XCTAssertFalse(script.contains("cursorlike"))
+        XCTAssertTrue(script.contains("custom_clis = []"))
+    }
+
+    func testRemoteInstallerConfigureScriptWithNoCustomCLIsIsEmptyList() {
+        let host = RemoteHost(id: "host-1", name: "devbox", host: "example.com")
+
+        let script = RemoteInstaller.configureRemoteHooksScript(host: host, customCLIs: [])
+
+        XCTAssertTrue(script.contains("custom_clis = []"))
+        XCTAssertTrue(script.contains("def install_custom():"))
+    }
+
     func testRemoteTraecliPermissionRequestRoutesAsPermissionAndUsesRemoteSessionNamespace() async throws {
         let payload: [String: Any] = [
             "hook_event_name": "permission_request",


### PR DESCRIPTION
Fixes #192.

Remote install previously only configured the five built-in CLIs (claude / codex / codebuddy / traecli / opencode) plus hermes. User-defined **custom CLIs** were never pushed to the remote host, so a custom CLI running over SSH got no hooks installed.

## What changed
- `configureRemoteHooksScript` now takes the custom CLI list (defaults to `ConfigInstaller.customCLIs()`), serializes it into the remote Python install script, and a new `install_custom()` writes their hooks alongside the built-ins.
- Reuses the existing `command_for(source)` (so events route through `codeisland-remote-hook.py` with the right `CODEISLAND_SOURCE`) and `remove_our_hooks` for clean reinstalls.

## Scope (deliberate)
Limited to the **claude** and **nested** JSON-hook formats — their stdin carries `hook_event_name`, so the remote hook handles them without a `--event` flag. These cover the Claude-fork / Codex-style CLIs that realistically run on a remote dev box.

Skipped remotely (still work locally): **flat** (Cursor-style, needs `--event` the remote hook can't supply), and the non-JSON formats (traecli YAML / copilot / kimi TOML / kiroAgent / cline).

## Tests
- New: custom claude CLI is serialized + `install_custom()` emitted + the whole script still compiles as Python (`assertPythonCompiles`); flat format is skipped (empty list); empty input is `custom_clis = []`.
- `swift test` — 344 passing.

Note: the remote SSH link can't be exercised in CI, so this is verified via the generated-script tests + Python compile; real end-to-end on a remote host welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)