### PR TITLE
[codex] Fix Warp tab activation

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import CodeIslandCore
 
 /// Activates the terminal window/tab running a specific Claude Code session.
@@ -1203,8 +1204,7 @@ struct TerminalActivator {
             bringToFront("Warp")
             return
         }
-        if warpApp.isHidden { warpApp.unhide() }
-        warpApp.activate()
+        raiseAppWithoutQuickTerminal(bundleId: warpBundleId)
 
         guard let cwd, !cwd.isEmpty else { return }
 
@@ -1221,18 +1221,31 @@ struct TerminalActivator {
             guard let best = matches.first else { return }
             if best.isActiveTab { return }
 
-            let targetPosition = best.tabIndexInWindow + 1
-            guard (1...9).contains(targetPosition) else { return }
-
-            DispatchQueue.main.async {
-                sendWarpGoToTab(position: targetPosition)
+            guard let targetPosition = warpShortcutPosition(for: best) else {
+                return
             }
+            guard hasAccessibilityPermission(prompt: true) else { return }
+
+            sendWarpGoToTabWhenFrontmost(
+                position: targetPosition,
+                bundleId: warpBundleId,
+                pid: warpApp.processIdentifier
+            )
         }
     }
 
-    /// Synthesize Warp's default "jump to tab N" shortcut (Cmd+<digit>, 1-9) for the
-    /// frontmost window. 10+ would require an extra keycode table; we bail for now.
-    private static func sendWarpGoToTab(position: Int) {
+    /// Convert Warp's 0-based tab index to its built-in shortcut semantics:
+    /// Cmd+1...Cmd+8 select tabs 1...8, and Cmd+9 selects the last tab.
+    private static func warpShortcutPosition(for match: WarpPaneMatch) -> Int? {
+        let targetPosition = match.tabIndexInWindow + 1
+        if (1...8).contains(targetPosition) { return targetPosition }
+        if targetPosition == match.tabCountInWindow { return 9 }
+        return nil
+    }
+
+    /// Synthesize Warp's default "jump to tab" shortcut for the frontmost window.
+    /// Positions 1...8 mean tabs 1...8; position 9 means the last tab.
+    private static func sendWarpGoToTab(position: Int, pid: pid_t) {
         guard (1...9).contains(position) else { return }
         // ANSI virtual keycodes for digits 1..9 (QWERTY layout).
         let digitKeyCodes: [CGKeyCode] = [18, 19, 20, 21, 23, 22, 26, 28, 25]
@@ -1241,11 +1254,44 @@ struct TerminalActivator {
 
         if let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true) {
             down.flags = .maskCommand
-            down.post(tap: .cghidEventTap)
+            down.postToPid(pid)
         }
         if let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) {
             up.flags = .maskCommand
-            up.post(tap: .cghidEventTap)
+            up.postToPid(pid)
         }
+    }
+
+    private static func sendWarpGoToTabWhenFrontmost(
+        position: Int,
+        bundleId: String,
+        pid: pid_t,
+        attemptsRemaining: Int = 6
+    ) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            let frontBundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+            if frontBundleId == bundleId {
+                sendWarpGoToTab(position: position, pid: pid)
+                return
+            }
+
+            guard attemptsRemaining > 0 else { return }
+            if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+                NSWorkspace.shared.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
+            }
+            sendWarpGoToTabWhenFrontmost(
+                position: position,
+                bundleId: bundleId,
+                pid: pid,
+                attemptsRemaining: attemptsRemaining - 1
+            )
+        }
+    }
+
+    private static func hasAccessibilityPermission(prompt: Bool) -> Bool {
+        let options = [
+            kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: prompt
+        ] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
     }
 }

--- a/Sources/CodeIsland/TerminalVisibilityDetector.swift
+++ b/Sources/CodeIsland/TerminalVisibilityDetector.swift
@@ -28,22 +28,27 @@ struct TerminalVisibilityDetector {
     /// Safe to call from the main thread — no AppleScript or subprocess calls.
     static func isTerminalFrontmostForSession(_ session: SessionSnapshot) -> Bool {
         guard let frontApp = NSWorkspace.shared.frontmostApplication else { return false }
+        let frontBundleId = frontApp.bundleIdentifier?.lowercased() ?? ""
 
         if isGhosttySessionVisibleInAnyWindow(session) {
             return true
+        }
+
+        if isWarpSession(session) {
+            guard frontBundleId == "dev.warp.warp-stable" else { return false }
+            return isWarpSessionTabActive(session)
         }
 
         if let termBundleId = session.termBundleId?.lowercased(),
            !termBundleId.isEmpty {
             // Bundle ID is known — match exclusively by bundle ID, don't fall through
             // to TERM_PROGRAM (avoids Warp's TERM_PROGRAM=Apple_Terminal false positive)
-            return frontApp.bundleIdentifier?.lowercased() == termBundleId
+            return frontBundleId == termBundleId
         }
 
         guard let termApp = session.termApp else { return false }
 
         let frontName = frontApp.localizedName?.lowercased() ?? ""
-        let bundleId = frontApp.bundleIdentifier?.lowercased() ?? ""
         let term = termApp.lowercased()
             .replacingOccurrences(of: ".app", with: "")
             .replacingOccurrences(of: "apple_", with: "")
@@ -51,7 +56,7 @@ struct TerminalVisibilityDetector {
 
         return normalizedFront.contains(term)
             || term.contains(normalizedFront)
-            || bundleId.contains(term)
+            || frontBundleId.contains(term)
     }
 
     // MARK: - Tab-level check (background thread only)
@@ -111,6 +116,9 @@ struct TerminalVisibilityDetector {
         if bid.contains("kitty") {
             return isKittyWindowActive(session)
         }
+        if bid == "dev.warp.warp-stable" {
+            return isWarpSessionTabActive(session)
+        }
 
         // Fallback: route by TERM_PROGRAM if bundle ID didn't match
         if let termApp = session.termApp {
@@ -127,6 +135,17 @@ struct TerminalVisibilityDetector {
 
         // Unknown terminal — can't determine tab, prefer showing notification
         return false
+    }
+
+    private static func isWarpSession(_ session: SessionSnapshot) -> Bool {
+        let bid = session.termBundleId?.lowercased() ?? ""
+        let term = session.termApp?.lowercased() ?? ""
+        return bid == "dev.warp.warp-stable" || term.contains("warp")
+    }
+
+    private static func isWarpSessionTabActive(_ session: SessionSnapshot) -> Bool {
+        guard let cwd = session.cwd, !cwd.isEmpty else { return false }
+        return (try? WarpPaneResolver().isActiveTab(cwd: cwd)) == true
     }
 
     /// Ghostty Quick Terminal can be visible while macOS still reports another app

--- a/Sources/CodeIslandCore/WarpPaneResolver.swift
+++ b/Sources/CodeIslandCore/WarpPaneResolver.swift
@@ -9,6 +9,7 @@ public struct WarpPaneMatch: Equatable {
     public let windowDbId: Int64
     public let cwd: String
     public let tabIndexInWindow: Int
+    public let tabCountInWindow: Int
     public let isActiveTab: Bool
     public let isPaneActive: Bool
     public let isPaneFocused: Bool
@@ -20,6 +21,7 @@ public struct WarpPaneMatch: Equatable {
         windowDbId: Int64,
         cwd: String,
         tabIndexInWindow: Int,
+        tabCountInWindow: Int,
         isActiveTab: Bool,
         isPaneActive: Bool,
         isPaneFocused: Bool
@@ -30,6 +32,7 @@ public struct WarpPaneMatch: Equatable {
         self.windowDbId = windowDbId
         self.cwd = cwd
         self.tabIndexInWindow = tabIndexInWindow
+        self.tabCountInWindow = tabCountInWindow
         self.isActiveTab = isActiveTab
         self.isPaneActive = isPaneActive
         self.isPaneFocused = isPaneFocused
@@ -46,8 +49,8 @@ public enum WarpPaneResolverError: Error, Equatable {
 /// given working directory, plus enough hierarchy (tab, window) to best-effort
 /// drive a focus keystroke afterwards.
 ///
-/// The database is always opened **read-only** over a URI with `nolock=1` so we
-/// do not contend with Warp while it is running. WAL pages are still honored.
+/// The database is always opened **read-only** over a URI. WAL pages are honored,
+/// and a short busy timeout avoids contending with Warp while it is writing.
 public struct WarpPaneResolver {
     public let sqlitePath: String
 
@@ -70,7 +73,14 @@ public struct WarpPaneResolver {
         guard FileManager.default.fileExists(atPath: sqlitePath) else {
             throw WarpPaneResolverError.sqliteFileMissing(sqlitePath)
         }
-        return try performQuery(cwdCandidates: variants)
+        return try performQuery(
+            cwdCandidates: variants,
+            caseInsensitive: WarpPaneResolver.isCaseInsensitivePath(cwd)
+        )
+    }
+
+    public func isActiveTab(cwd: String) throws -> Bool {
+        try resolve(cwd: cwd).contains { $0.isActiveTab }
     }
 
     // MARK: - Cwd normalization
@@ -103,7 +113,7 @@ public struct WarpPaneResolver {
 
     // MARK: - SQLite
 
-    private func performQuery(cwdCandidates: [String]) throws -> [WarpPaneMatch] {
+    private func performQuery(cwdCandidates: [String], caseInsensitive: Bool) throws -> [WarpPaneMatch] {
         let uri = WarpPaneResolver.fileURI(for: sqlitePath)
         var db: OpaquePointer?
         let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_URI | SQLITE_OPEN_NOMUTEX
@@ -115,11 +125,16 @@ public struct WarpPaneResolver {
         }
         defer { sqlite3_close_v2(handle) }
 
-        // Let sqlite block briefly if Warp is holding a write lock. Ignored when
-        // opened with nolock=1 but cheap insurance for legacy Warp builds.
+        // Let sqlite block briefly if Warp is holding a write lock.
         sqlite3_busy_timeout(handle, 150)
 
         let placeholders = cwdCandidates.map { _ in "?" }.joined(separator: ", ")
+        let whereClause: String
+        if caseInsensitive {
+            whereClause = "tp.cwd IN (\(placeholders)) OR tp.cwd COLLATE NOCASE IN (\(placeholders))"
+        } else {
+            whereClause = "tp.cwd IN (\(placeholders))"
+        }
         let sql = """
         SELECT
             tp.id,
@@ -133,13 +148,17 @@ public struct WarpPaneResolver {
             (
                 SELECT COUNT(*) FROM tabs t2
                 WHERE t2.window_id = t.window_id AND t2.id < t.id
-            ) AS tab_idx
+            ) AS tab_idx,
+            (
+                SELECT COUNT(*) FROM tabs t3
+                WHERE t3.window_id = t.window_id
+            ) AS tab_count
         FROM terminal_panes tp
         LEFT JOIN pane_leaves pl ON tp.id = pl.pane_node_id AND pl.kind = 'terminal'
         LEFT JOIN pane_nodes pn ON tp.id = pn.id
         LEFT JOIN tabs t ON pn.tab_id = t.id
         LEFT JOIN windows w ON t.window_id = w.id
-        WHERE tp.cwd IN (\(placeholders))
+        WHERE \(whereClause)
         ORDER BY tp.is_active DESC, focused DESC, tp.id DESC
         """
 
@@ -157,6 +176,18 @@ public struct WarpPaneResolver {
             guard bindStatus == SQLITE_OK else {
                 let message = String(cString: sqlite3_errmsg(handle))
                 throw WarpPaneResolverError.queryFailed("bind \(idx): \(message)")
+            }
+        }
+        if caseInsensitive {
+            let offset = cwdCandidates.count
+            for (idx, candidate) in cwdCandidates.enumerated() {
+                let bindStatus = candidate.withCString { cstr in
+                    sqlite3_bind_text(query, Int32(offset + idx + 1), cstr, -1, Self.sqliteTransient)
+                }
+                guard bindStatus == SQLITE_OK else {
+                    let message = String(cString: sqlite3_errmsg(handle))
+                    throw WarpPaneResolverError.queryFailed("bind nocase \(idx): \(message)")
+                }
             }
         }
 
@@ -178,6 +209,7 @@ public struct WarpPaneResolver {
             let windowId = sqlite3_column_int64(query, 6)
             let activeTabIndex = Int(sqlite3_column_int(query, 7))
             let tabIndex = Int(sqlite3_column_int(query, 8))
+            let tabCount = Int(sqlite3_column_int(query, 9))
 
             matches.append(WarpPaneMatch(
                 paneUUID: uuidHex,
@@ -186,6 +218,7 @@ public struct WarpPaneResolver {
                 windowDbId: windowId,
                 cwd: cwdText,
                 tabIndexInWindow: tabIndex,
+                tabCountInWindow: tabCount,
                 isActiveTab: activeTabIndex == tabIndex,
                 isPaneActive: paneActive,
                 isPaneFocused: paneFocused
@@ -208,7 +241,25 @@ public struct WarpPaneResolver {
             default:  encoded.unicodeScalars.append(scalar)
             }
         }
-        return "file://\(encoded)?mode=ro&nolock=1"
+        return "file://\(encoded)?mode=ro"
+    }
+
+    /// macOS paths are usually case-insensitive even though the original casing
+    /// can differ between Codex's cwd and Warp's SQLite row. Respect case-sensitive
+    /// volumes by walking to the nearest existing parent and reading its volume flag.
+    static func isCaseInsensitivePath(_ path: String) -> Bool {
+        var url = URL(fileURLWithPath: path)
+        let fm = FileManager.default
+        while !fm.fileExists(atPath: url.path) {
+            let parent = url.deletingLastPathComponent()
+            if parent.path == url.path { break }
+            url = parent
+        }
+        if let values = try? url.resourceValues(forKeys: [.volumeSupportsCaseSensitiveNamesKey]),
+           let supportsCaseSensitive = values.volumeSupportsCaseSensitiveNames {
+            return !supportsCaseSensitive
+        }
+        return true
     }
 
     /// The canonical `SQLITE_TRANSIENT` sentinel as a Swift destructor type.

--- a/Tests/CodeIslandCoreTests/WarpPaneResolverTests.swift
+++ b/Tests/CodeIslandCoreTests/WarpPaneResolverTests.swift
@@ -82,6 +82,18 @@ final class WarpPaneResolverTests: XCTestCase {
         XCTAssertTrue(hit.isPaneFocused)
     }
 
+    func testResolveMatchesCwdCaseInsensitivelyOnDefaultMacVolumes() throws {
+        let dbPath = try createTestDatabase(panes: [
+            TestPane(id: 42, uuid: "DEADBEEF", cwd: "/Users/bob/codeisland", isActive: true, isFocused: true, tabId: 5, windowId: 3, activeTabIndex: 0)
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let resolver = WarpPaneResolver(sqlitePath: dbPath)
+        let matches = try resolver.resolve(cwd: "/Users/bob/CodeIsland")
+        XCTAssertEqual(matches.first?.paneId, 42)
+        XCTAssertEqual(matches.first?.cwd, "/Users/bob/codeisland")
+    }
+
     func testResolveResolvesFirmlinkVariant() throws {
         let dbPath = try createTestDatabase(panes: [
             TestPane(id: 1, uuid: "01", cwd: "/private/tmp/work", isActive: true, isFocused: true, tabId: 1, windowId: 1, activeTabIndex: 0)
@@ -124,25 +136,40 @@ final class WarpPaneResolverTests: XCTestCase {
 
         let w10t20 = try XCTUnwrap(try resolver.resolve(cwd: "/w10-t20").first)
         XCTAssertEqual(w10t20.tabIndexInWindow, 0)
+        XCTAssertEqual(w10t20.tabCountInWindow, 3)
         XCTAssertFalse(w10t20.isActiveTab)
 
         let w10t22 = try XCTUnwrap(try resolver.resolve(cwd: "/w10-t22").first)
         XCTAssertEqual(w10t22.tabIndexInWindow, 2)
+        XCTAssertEqual(w10t22.tabCountInWindow, 3)
         XCTAssertTrue(w10t22.isActiveTab)
 
         let w11t30 = try XCTUnwrap(try resolver.resolve(cwd: "/w11-t30").first)
         XCTAssertEqual(w11t30.tabIndexInWindow, 0)
+        XCTAssertEqual(w11t30.tabCountInWindow, 1)
         XCTAssertTrue(w11t30.isActiveTab)
+    }
+
+    func testIsActiveTabReflectsWindowActiveTabIndex() throws {
+        let dbPath = try createTestDatabase(panes: [
+            TestPane(id: 1, uuid: "01", cwd: "/inactive", isActive: true, isFocused: true, tabId: 10, windowId: 1, activeTabIndex: 1),
+            TestPane(id: 2, uuid: "02", cwd: "/active", isActive: false, isFocused: false, tabId: 11, windowId: 1, activeTabIndex: 1)
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let resolver = WarpPaneResolver(sqlitePath: dbPath)
+        XCTAssertFalse(try resolver.isActiveTab(cwd: "/inactive"))
+        XCTAssertTrue(try resolver.isActiveTab(cwd: "/active"))
     }
 
     func testFileURIEncodesSpacesAndSpecials() {
         XCTAssertEqual(
             WarpPaneResolver.fileURI(for: "/Users/alice/my path/warp.sqlite"),
-            "file:///Users/alice/my%20path/warp.sqlite?mode=ro&nolock=1"
+            "file:///Users/alice/my%20path/warp.sqlite?mode=ro"
         )
         XCTAssertEqual(
             WarpPaneResolver.fileURI(for: "/tmp/a#b?c%.sqlite"),
-            "file:///tmp/a%23b%3Fc%25.sqlite?mode=ro&nolock=1"
+            "file:///tmp/a%23b%3Fc%25.sqlite?mode=ro"
         )
     }
 


### PR DESCRIPTION
## Summary
- raise Warp via the existing NSWorkspace.openApplication helper instead of NSRunningApplication.activate
- read Warp SQLite state without nolock=1 and match cwd case-insensitively on default macOS volumes
- wait until Warp is frontmost before sending the Cmd+digit tab shortcut, including Warp's Cmd+9 last-tab behavior
- make Warp smart-suppress tab-aware so a foreground Warp window on the wrong tab does not hide the CodeIsland panel

## Why
Warp tab activation could degrade to app-level activation or silently fail when CodeIsland tried to jump back to a session running in a different Warp tab. On this machine the resolver also failed because SQLite could not open Warp's database with `nolock=1`.

A second issue was that smart suppress treated Warp being frontmost as equivalent to the target session being visible. If Warp was frontmost on tab A while the active CodeIsland session was on tab B, CodeIsland could suppress the panel and make the session hard to jump to. The suppress check now uses Warp's active tab state for Warp sessions.

## Test plan
- `git diff --check`
- `swift test --filter WarpPaneResolverTests`
- `swift test`
