### PR TITLE
fix: clean stale remote socket before -R forwarding (fixes #206)

### DIFF
--- a/Sources/CodeIsland/SSHForwarder.swift
+++ b/Sources/CodeIsland/SSHForwarder.swift
@@ -35,6 +35,12 @@ final class SSHForwarder {
         let currentGeneration = generation
         status = .connecting
 
+        // Remove stale remote socket left over from a previous tunnel.
+        // macOS system SSH (LibreSSL) does not honour StreamLocalBindUnlink=yes
+        // for -R remote forwarding, so a leftover socket causes "remote port
+        // forwarding failed" on reconnect.  See #206.
+        cleanupStaleRemoteSocket(host: host, remoteSocketPath: remoteSocketPath)
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
         process.arguments = buildArguments(host: host, localSocketPath: localSocketPath, remoteSocketPath: remoteSocketPath)
@@ -97,6 +103,42 @@ final class SSHForwarder {
             status = .disconnected
         }
         self.process = nil
+    }
+
+    /// Remove a stale Unix-domain socket on the remote host before forwarding.
+    ///
+    /// macOS system SSH (`/usr/bin/ssh`, LibreSSL build) ignores
+    /// `StreamLocalBindUnlink=yes` for `-R` (remote) forwarding.  When a tunnel
+    /// drops the listen socket is left behind and reconnect fails with
+    /// "remote port forwarding failed for listen path …".  A quick `rm -f`
+    /// over SSH sidesteps the issue.  See issue #206.
+    private func cleanupStaleRemoteSocket(host: RemoteHost, remoteSocketPath: String) {
+        let target = host.sshTarget
+        guard !target.isEmpty else { return }
+
+        var args: [String] = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+        ]
+        if let port = host.port {
+            args += ["-p", String(port)]
+        }
+        let trimmedIdentity = host.identityFile.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedIdentity.isEmpty {
+            args += ["-i", trimmedIdentity]
+        }
+        args += [target, "rm", "-f", remoteSocketPath]
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        proc.arguments = args
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        proc.environment = buildEnvironment(host: host)
+
+        try? proc.run()
+        proc.waitUntilExit()
     }
 
     private func buildArguments(host: RemoteHost, localSocketPath: String, remoteSocketPath: String) -> [String] {

--- a/Sources/CodeIsland/SSHForwarder.swift
+++ b/Sources/CodeIsland/SSHForwarder.swift
@@ -113,9 +113,23 @@ final class SSHForwarder {
     /// "remote port forwarding failed for listen path …".  A quick `rm -f`
     /// over SSH sidesteps the issue.  See issue #206.
     private func cleanupStaleRemoteSocket(host: RemoteHost, remoteSocketPath: String) {
-        let target = host.sshTarget
-        guard !target.isEmpty else { return }
+        guard !host.sshTarget.isEmpty else { return }
 
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        proc.arguments = Self.cleanupArguments(host: host, remoteSocketPath: remoteSocketPath)
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        proc.environment = buildEnvironment(host: host)
+
+        try? proc.run()
+        proc.waitUntilExit()
+    }
+
+    /// Build SSH arguments that remove a stale remote socket file.
+    /// Extracted for testability.  See `cleanupStaleRemoteSocket`.
+    static func cleanupArguments(host: RemoteHost, remoteSocketPath: String) -> [String] {
         var args: [String] = [
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=5",
@@ -127,18 +141,8 @@ final class SSHForwarder {
         if !trimmedIdentity.isEmpty {
             args += ["-i", trimmedIdentity]
         }
-        args += [target, "rm", "-f", remoteSocketPath]
-
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-        proc.arguments = args
-        proc.standardInput = FileHandle.nullDevice
-        proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
-        proc.environment = buildEnvironment(host: host)
-
-        try? proc.run()
-        proc.waitUntilExit()
+        args += [host.sshTarget, "rm", "-f", remoteSocketPath]
+        return args
     }
 
     private func buildArguments(host: RemoteHost, localSocketPath: String, remoteSocketPath: String) -> [String] {

--- a/Tests/CodeIslandTests/SSHForwarderTests.swift
+++ b/Tests/CodeIslandTests/SSHForwarderTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import CodeIsland
+
+@MainActor
+final class SSHForwarderTests: XCTestCase {
+
+    // MARK: - cleanupArguments
+
+    func testCleanupArgumentsBasic() {
+        let host = RemoteHost(name: "test", host: "192.168.1.10", user: "alice")
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-501.sock")
+
+        XCTAssertEqual(args, [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+            "alice@192.168.1.10", "rm", "-f", "/tmp/codeisland-501.sock",
+        ])
+    }
+
+    func testCleanupArgumentsIncludesIdentityFile() {
+        let host = RemoteHost(
+            name: "test",
+            host: "192.168.1.10",
+            user: "alice",
+            identityFile: "~/.ssh/id_ed25519"
+        )
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-501.sock")
+
+        XCTAssertTrue(args.contains("-i"))
+        XCTAssertTrue(args.contains("~/.ssh/id_ed25519"))
+        // -i must appear before the target
+        let iIndex = args.firstIndex(of: "-i")!
+        let targetIndex = args.firstIndex(of: "alice@192.168.1.10")!
+        XCTAssertLessThan(iIndex, targetIndex)
+    }
+
+    func testCleanupArgumentsIncludesPort() {
+        let host = RemoteHost(name: "test", host: "192.168.1.10", user: "alice", port: 2222)
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-501.sock")
+
+        XCTAssertTrue(args.contains("-p"))
+        XCTAssertTrue(args.contains("2222"))
+    }
+
+    func testCleanupArgumentsIncludesPortAndIdentity() {
+        let host = RemoteHost(
+            name: "test",
+            host: "example.com",
+            user: "bob",
+            port: 2222,
+            identityFile: "/Users/bob/.ssh/id_rsa"
+        )
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-1000.sock")
+
+        XCTAssertTrue(args.contains("-p"))
+        XCTAssertTrue(args.contains("2222"))
+        XCTAssertTrue(args.contains("-i"))
+        XCTAssertTrue(args.contains("/Users/bob/.ssh/id_rsa"))
+        // Last three elements are always: target, "rm", "-f", socketPath
+        let suffix = args.suffix(4)
+        XCTAssertEqual(Array(suffix), ["bob@example.com", "rm", "-f", "/tmp/codeisland-1000.sock"])
+    }
+
+    func testCleanupArgumentsTrimsIdentityWhitespace() {
+        let host = RemoteHost(
+            name: "test",
+            host: "192.168.1.10",
+            user: "alice",
+            identityFile: "  ~/.ssh/id_ed25519  "
+        )
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-501.sock")
+
+        // Should include -i with trimmed value
+        let iIndex = args.firstIndex(of: "-i")!
+        XCTAssertEqual(args[iIndex + 1], "~/.ssh/id_ed25519")
+    }
+
+    func testCleanupArgumentsEmptyIdentityOmitted() {
+        let host = RemoteHost(name: "test", host: "192.168.1.10", user: "alice", identityFile: "")
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-501.sock")
+
+        XCTAssertFalse(args.contains("-i"))
+    }
+
+    func testCleanupArgumentsEmptyPortOmitted() {
+        let host = RemoteHost(name: "test", host: "192.168.1.10", user: "alice")
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-501.sock")
+
+        XCTAssertFalse(args.contains("-p"))
+    }
+
+    func testCleanupArgumentsAlwaysIncludesRm() {
+        let host = RemoteHost(name: "test", host: "10.0.0.1", user: "root")
+        let socketPath = "/tmp/codeisland-0.sock"
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: socketPath)
+
+        // Must contain: rm -f <socketPath>
+        let rmIndex = args.firstIndex(of: "rm")!
+        XCTAssertEqual(args[rmIndex + 1], "-f")
+        XCTAssertEqual(args[rmIndex + 2], socketPath)
+    }
+
+    func testCleanupArgumentsBatchModeAlwaysOn() {
+        let host = RemoteHost(name: "test", host: "10.0.0.1", user: "root")
+        let args = SSHForwarder.cleanupArguments(host: host, remoteSocketPath: "/tmp/codeisland-0.sock")
+
+        XCTAssertTrue(args.contains("BatchMode=yes"))
+        XCTAssertTrue(args.contains("ConnectTimeout=5"))
+    }
+}


### PR DESCRIPTION
## Problem

macOS system SSH (`/usr/bin/ssh`, LibreSSL build) ignores `StreamLocalBindUnlink=yes` for `-R` remote Unix socket forwarding. When an SSH tunnel drops (sleep, network blip, user disconnect), the listen socket file is left behind on the server. Reconnect attempts fail with:

```
remote port forwarding failed for listen path /tmp/codeisland-<uid>.sock
```

which surfaces as `ssh exited(255)` in the UI.

## Fix

Add a `cleanupStaleRemoteSocket()` step in `SSHForwarder.connect` that runs `rm -f <remoteSocketPath>` via SSH before establishing the tunnel. This mirrors how `StreamLocalBindUnlink=yes` is *supposed* to work but doesn't on the LibreSSL build.

The cleanup uses a short `ConnectTimeout=5` and runs synchronously before the tunnel process, so a failed cleanup (e.g. server unreachable) doesn't block the normal connect flow — the tunnel will fail on its own in that case.

Closes #206