### PR TITLE
feat(activator): jump to host GUI client that embeds an agent as a server

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -103,12 +103,26 @@ struct TerminalActivator {
             return
         }
 
-        // When termBundleId is missing and the source has a known desktop app that's
-        // running, prefer the desktop app over possibly-stale TERM_PROGRAM env. This
-        // handles e.g. OpenCode CLI launched from Ghostty but editing in VS Code — without
-        // this, the inherited TERM_PROGRAM=ghostty would jump to the wrong terminal.
-        if session.termBundleId == nil,
-           let nativeBundleId = sourceToNativeAppBundleId[session.source],
+        // --- Host GUI client detection (e.g. OpenChamber embedding OpenCode as a server) ---
+        // When an agent is spawned by a GUI client app — not from a terminal and not the
+        // agent's own desktop app — clicking the session should bring that host client to
+        // front instead of falling through to the terminal or the agent's native desktop
+        // app. Walk the CLI process ancestry looking for the nearest running regular GUI
+        // app that is neither a known terminal nor a known agent-native app; that app is
+        // the host. Generic by design: any current/future client (OpenChamber, …) works
+        // without hardcoding bundle IDs. Runs BEFORE the sourceToNativeAppBundleId branch
+        // below so a coincidentally-running agent desktop app never wins over the real host.
+        if let hostBid = resolveHostClientBundleId(for: session) {
+            activateByBundleId(hostBid)
+            return
+        }
+
+        // When the source has a known desktop app that's running, prefer the desktop
+        // app over the terminal. This handles e.g. OpenCode CLI launched from Ghostty but
+        // editing in VS Code — without this, the inherited TERM_PROGRAM=ghostty would jump
+        // to the wrong terminal. Also covers cases where the terminal bundle ID is present
+        // but the user wants to focus the desktop IDE instead (e.g. opencode → OpenCode).
+        if let nativeBundleId = sourceToNativeAppBundleId[session.source],
            NSWorkspace.shared.runningApplications.contains(where: { $0.bundleIdentifier == nativeBundleId }) {
             activateByBundleId(nativeBundleId)
             return
@@ -251,6 +265,50 @@ struct TerminalActivator {
         } else {
             bringToFront(termApp)
         }
+    }
+
+    /// Walks the CLI process ancestry looking for the nearest running GUI app that is
+    /// neither a known terminal nor a known agent-native app. Returns its bundle ID, or
+    /// nil when the agent runs in a plain terminal / its own desktop app / under launchd.
+    /// Used to jump back to GUI host clients (e.g. OpenChamber) that embed an agent such
+    /// as OpenCode as a managed server process. The ancestor walk is bounded (≤32 hops)
+    /// and click-driven, so cost is negligible.
+    private static func resolveHostClientBundleId(for session: SessionSnapshot) -> String? {
+        guard let pid = session.cliPid, pid > 0 else { return nil }
+
+        // Bundle IDs that must NEVER be treated as a "host client": known terminals
+        // (handled by tab/window-level switching further down) and agent-native desktop
+        // apps (handled by the nativeAppBundles / sourceToNativeAppBundleId branches).
+        var excluded = Set(knownTerminals.map { $0.bundleId })
+        excluded.formUnion(nativeAppBundles.keys)
+        excluded.formUnion(sourceToNativeAppBundleId.values)
+
+        // Snapshot once; match by processIdentifier while walking up the tree.
+        let regularApps = NSWorkspace.shared.runningApplications.filter {
+            $0.activationPolicy == .regular && $0.bundleIdentifier != nil
+        }
+
+        var current = pid
+        var seen = Set<pid_t>()
+        for _ in 0..<32 {
+            guard current > 1, !seen.contains(current) else { break }
+            seen.insert(current)
+            if let app = regularApps.first(where: { $0.processIdentifier == current }),
+               let bid = app.bundleIdentifier,
+               !excluded.contains(bid) {
+                return bid
+            }
+            guard let ppid = parentPID(of: current), ppid > 1 else { break }
+            current = ppid
+        }
+        return nil
+    }
+
+    private static func parentPID(of pid: pid_t) -> pid_t? {
+        var info = proc_bsdinfo()
+        let ret = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(MemoryLayout<proc_bsdinfo>.size))
+        guard ret > 0, info.pbi_ppid > 0 else { return nil }
+        return pid_t(info.pbi_ppid)
     }
 
     // MARK: - Ghostty (AppleScript: match by CWD + session ID in title)


### PR DESCRIPTION
## Problem

When an AI agent (e.g. OpenCode) is spawned by a **GUI client application** rather than by a terminal — for example [OpenChamber](https://github.com/…) (an open-source OpenCode client) embedding OpenCode as a managed server process — clicking the session in the notch panel jumps to the **wrong target**.

Instead of bringing the host client (OpenChamber) to front, CodeIsland falls through to the terminal tab/window matcher and either does nothing useful or activates a terminal that has nothing to do with the running session.

### Root cause

`TerminalActivator.activate()` decides where to jump purely from static fields captured at hook time:

- `termBundleId` — the `__CFBundleIdentifier` of whatever process hosted the CLI. For an embedded server this is either empty or points at the host's bundled shell/PTY, not the GUI app itself.
- `sourceToNativeAppBundleId` — a hardcoded `source → desktop-app bundle id` map. It only knows the agent's *own* desktop app (e.g. `ai.opencode.desktop`), not arbitrary third-party host clients like OpenChamber.

So a host client that embeds the agent as a server is invisible to every existing branch, and the jump degrades to the generic terminal fallback.

There is also no way to add every new host client by hardcoding bundle IDs — that does not scale.

## Solution

Add a **generic host-client resolver** that walks the CLI process ancestry to find the nearest running GUI app that actually spawned the agent, regardless of its bundle id.

### New: `resolveHostClientBundleId(for:)`

1. Start from `session.cliPid` (the agent PID, already captured from the bridge/plugin `_ppid`).
2. Build an **exclusion set** = known terminals ∪ `nativeAppBundles` keys ∪ `sourceToNativeAppBundleId` values. These are the apps that already have dedicated handling and must never be mistaken for a "host".
3. Walk up the parent PID chain (bounded at 32 hops, cycle-safe via a `seen` set) using `proc_pidinfo(PROC_PIDTBSDINFO)`.
4. The first `.regular` activation-policy app found that is **not** in the exclusion set is the host client. Return its bundle id.

```swift
if let hostBid = resolveHostClientBundleId(for: session) {
    activateByBundleId(hostBid)
    return
}
```

### Why it's generic

- **No hardcoded bundle IDs.** OpenChamber, and any future client that fork-execs an agent, works with zero config changes.
- **The exclusion set is self-maintaining.** When new terminals / agent-native apps are registered later, they're automatically excluded from host detection.
- **Zero false positives for the terminal case.** When a CLI runs inside a real terminal, the first GUI app on the ancestry chain *is* the terminal — which is excluded — and the terminal's parent is WindowServer/`launchd` (pid ≤ 1, stops the walk). So `resolveHostClientBundleId` returns `nil` and all existing terminal-level jump paths are untouched.

### Ordering

Host detection runs **before** `sourceToNativeAppBundleId`, so a coincidentally-running agent desktop app (e.g. OpenCode APP open in the background while the CLI is actually managed by OpenChamber) never wins over the real host.

## Behavior changes

One intentional change beyond the new resolver: the `sourceToNativeAppBundleId` fallback **no longer requires `termBundleId == nil`**.

| Scenario                                                            | Before                                                       | After                     |
| ------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------- |
| CLI in a standalone terminal, its desktop app **not** running           | jump terminal                                                | jump terminal (unchanged) |
| CLI in a standalone terminal, its desktop app **happens to be** running | jump terminal                                                | jump **desktop app**          |
| CLI embedded by a host client (OpenChamber)                         | jump terminal (wrong)                                        | **jump host client** ✓        |
| CLI in an IDE integrated terminal                                   | handled by `nativeAppBundles`/`isIDETerminal` branch (unchanged) | unchanged                 |

The middle row is the only user-visible change for existing setups: users who run a CLI in an external terminal while the matching desktop app is open will now focus the desktop app instead of the terminal. This matches the intent of "focus where the work is".

## Edge cases & safety

- **`cliPid` missing or dead** → `guard pid > 0` returns `nil`, falls back to existing logic. No crash, no behavior change.
- **Agent reparented to `launchd`** (daemon/managed launch) → walk stops at pid 1, returns `nil`, falls back. Safe degradation.
- **Host client itself is a known terminal in disguise** → excluded by the terminal set; won't be selected.
- **Performance** → only invoked on click (not a hot path); ≤32 `proc_pidinfo` calls + one `runningApplications` snapshot. Negligible.

