### PR TITLE
fix(mascot): map cursor-cli and qoder-cli to correct mascots

### DIFF
--- a/CodeIsland.entitlements
+++ b/CodeIsland.entitlements
@@ -8,7 +8,5 @@
 	<true/>
 	<key>com.apple.security.device.bluetooth</key>
 	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 </dict>
 </plist>

--- a/Sources/CodeIsland/MascotView.swift
+++ b/Sources/CodeIsland/MascotView.swift
@@ -29,13 +29,13 @@ struct MascotView: View {
             case "gemini", "google-antigravity":
                 // Google Antigravity is Gemini-based — reuse the Gemini mascot.
                 GeminiView(status: status, size: size)
-            case "cursor":
+            case "cursor", "cursor-cli":
                 CursorView(status: status, size: size)
             case "trae", "traecn", "traecli":
                 TraeView(status: status, size: size)
             case "copilot":
                 CopilotView(status: status, size: size)
-            case "qoder":
+            case "qoder", "qoder-cli":
                 QoderView(status: status, size: size)
             case "droid":
                 DroidView(status: status, size: size)

--- a/ios/CodeIslandCompanion/Shared/CompanionDisplayText.swift
+++ b/ios/CodeIslandCompanion/Shared/CompanionDisplayText.swift
@@ -11,8 +11,10 @@ enum CompanionDisplayText {
             return "CODEX"
         case "gemini":
             return "GEMINI"
-        case "cursor":
+        case "cursor", "cursor-cli":
             return "CURSOR"
+        case "qoder", "qoder-cli":
+            return "QODER"
         case "opencode":
             return "OPENCODE"
         case "qwen":

--- a/ios/CodeIslandCompanion/Shared/SharedMascotView.swift
+++ b/ios/CodeIslandCompanion/Shared/SharedMascotView.swift
@@ -66,13 +66,13 @@ struct SharedMascotView: View {
                 DexView(status: status, size: size)
             case "gemini":
                 GeminiView(status: status, size: size)
-            case "cursor":
+            case "cursor", "cursor-cli":
                 CursorView(status: status, size: size)
             case "trae", "traecn", "traecli":
                 TraeView(status: status, size: size)
             case "copilot":
                 CopilotView(status: status, size: size)
-            case "qoder":
+            case "qoder", "qoder-cli":
                 QoderView(status: status, size: size)
             case "droid":
                 DroidView(status: status, size: size)


### PR DESCRIPTION
Fixes follow-up reported in #220.

## Summary

- Map `cursor-cli` and `qoder-cli` source IDs to the Cursor / Qoder mascots in `MascotView` and `SharedMascotView`.
- Bridge already promotes terminal `cursor-agent` / `qodercli` sessions to these `-cli` IDs (#134), and `ESP32Protocol` + `SessionSnapshot.sourceLabel` already handle them — only the SwiftUI mascot router was missing the cases, so sessions fell through to the default Clawd (Claude) mascot.
- Align iOS companion source labels for `-cli` variants in `CompanionDisplayText` (`CURSOR` / `QODER` instead of uppercasing the raw ID).
- Remove a duplicate `com.apple.security.cs.disable-library-validation` entry in `CodeIsland.entitlements` that causes `./build.sh` codesign to fail when building from source.

## 中文说明

- 在 `MascotView` / `SharedMascotView` 中为 `cursor-cli`、`qoder-cli` 补上吉祥物路由，复用现有 Cursor / Qoder 角色（与 #134 中 bridge 识别、`ESP32Protocol`、Buddy 固件 slot 的设计一致）。
- 修复前：终端里的 cursor-agent / qodercli 会话会被 bridge 正确识别为 `cursor-cli` / `qoder-cli`，但 UI 层未匹配这些 source，回退成 Clawd（Claude）——与 #220 评论中「cursor cli 显示 cc 吉祥物」一致。
- iOS 伴侣端 `CompanionDisplayText` 同步处理 `-cli` 来源名。
- 顺带删除 entitlements 里重复的 `disable-library-validation` 键，避免本地 `./build.sh` 签名失败。

## Test Plan

- [x] `./build.sh` — release build + ad-hoc codesign succeeds
- [x] Manual: `cursor-agent` session in terminal shows Cursor mascot in notch panel (not Clawd)
- [x] Manual: `qodercli` session shows Qoder mascot after directory trust + hook reinstall
- [ ] Maintainer: `swift test` (341+ tests; not run in this contributor environment — XCTest module unavailable outside Xcode toolchain)


Made with [Cursor](https://cursor.com)