### PR TITLE
修复 Codex 多行命令规则的字符串转义

### DIFF
--- a/Sources/CodeIsland/CodexPermissionRules.swift
+++ b/Sources/CodeIsland/CodexPermissionRules.swift
@@ -196,6 +196,8 @@ struct CodexPermissionRules {
         let escaped = value
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
         return "\"\(escaped)\""
     }
 

--- a/Tests/CodeIslandTests/AppStatePermissionFlowTests.swift
+++ b/Tests/CodeIslandTests/AppStatePermissionFlowTests.swift
@@ -275,6 +275,27 @@ final class AppStatePermissionFlowTests: XCTestCase {
         XCTAssertTrue(rules.contains(#"decision = "allow""#))
     }
 
+    func testCodexAlwaysAllowEscapesMultilineRuleArguments() throws {
+        let codexHome = makeTemporaryCodexHome()
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let event = try makePermissionRequestEvent(
+            sessionId: "s-codex-multiline-rule",
+            toolName: "Bash",
+            toolInput: [
+                "command": "node -e 'console.log(\"a\")\nconsole.log(\"b\")\r\n'"
+            ],
+            source: "codex"
+        )
+
+        let rules = CodexPermissionRules()
+        XCTAssertTrue(rules.persistAlwaysAllowRule(for: event))
+
+        let contents = try readCodeIslandRules(in: codexHome)
+        XCTAssertTrue(contents.contains(#"pattern = ["node", "-e", "console.log(\"a\")\nconsole.log(\"b\")\r\n"]"#))
+        XCTAssertFalse(contents.contains("console.log(\\\"a\\\")\nconsole.log(\\\"b\\\")\r\n"))
+    }
+
     func testCodexAlwaysAllowMCPToolPersistsApprovalModeWithoutUnsupportedUpdatedPermissions() async throws {
         let codexHome = makeTemporaryCodexHome()
         defer { try? FileManager.default.removeItem(at: codexHome) }


### PR DESCRIPTION
Fixes #250

在生成 Codex Starlark rules 时，额外转义换行符 `\n` 和回车符 `\r`。
增加回归测试，覆盖 Codex Always Allow 持久化多行命令参数的场景。