### PR TITLE
fix(activator): recognize Terax terminal for click-to-jump

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -6,7 +6,9 @@ import CodeIslandCore
 /// Supports tab-level switching for: Ghostty, iTerm2, Terminal.app, WezTerm, kitty.
 /// Falls back to app-level activation for: Alacritty, Warp, Hyper, Tabby, Rio.
 struct TerminalActivator {
-    private static let knownTerminals: [(name: String, bundleId: String)] = [
+    // Internal (not private) so support tests can assert a terminal is recognized,
+    // matching sourceToNativeAppBundleId's visibility. See TeraxSupportTests.
+    static let knownTerminals: [(name: String, bundleId: String)] = [
         ("cmux", "com.cmuxterm.app"),
         ("Ghostty", "com.mitchellh.ghostty"),
         ("iTerm2", "com.googlecode.iterm2"),
@@ -14,6 +16,7 @@ struct TerminalActivator {
         ("Kaku", "fun.tw93.kaku"),
         ("kitty", "net.kovidgoyal.kitty"),
         ("Alacritty", "org.alacritty"),
+        ("Terax", "app.crynta.terax"),
         ("Warp", "dev.warp.Warp-Stable"),
         ("Terminal", "com.apple.Terminal"),
     ]
@@ -165,6 +168,20 @@ struct TerminalActivator {
                 NSWorkspace.shared.runningApplications.contains(where: { $0.bundleIdentifier == bid })
             })
             activateByBundleId(runningBundle ?? "com.superset.desktop")
+            return
+        }
+
+        // --- Terax (native webview terminal): app-level activation only ---
+        // Like Superset, Terax (app.crynta.terax) is a single-window app whose tabs are
+        // drawn inside a webview. It exports no per-pane env id (only TERAX_TERMINAL /
+        // TERAX_BLOCKS) and ships no URL scheme, AppleScript dictionary, focus CLI, or
+        // native tab shortcut — and its tabs are absent from the accessibility tree — so
+        // per-tab precision is impossible upstream. Without this branch Terax has no
+        // TERM_PROGRAM, so detectRunningTerminal() would misroute the click to whichever
+        // other terminal happens to be running. Bring its window forward (Space-aware,
+        // same as Superset) via bundle id.
+        if session.termBundleId == "app.crynta.terax" || lower == "terax" {
+            activateByBundleId("app.crynta.terax")
             return
         }
 

--- a/Tests/CodeIslandTests/TeraxSupportTests.swift
+++ b/Tests/CodeIslandTests/TeraxSupportTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import CodeIsland
+@testable import CodeIslandCore
+
+/// Terax (app.crynta.terax) support. Terax is a native single-window terminal whose
+/// tabs live inside a webview; it sets no TERM_PROGRAM and ships no URL scheme,
+/// AppleScript dictionary, focus CLI, or native tab shortcut, so — like Superset —
+/// click-to-jump can only bring its window forward (app-level activation).
+final class TeraxSupportTests: XCTestCase {
+
+    private func makeSession(termBundleId: String?, source: String) -> SessionSnapshot {
+        var session = SessionSnapshot()
+        session.source = source
+        session.termBundleId = termBundleId
+        return session
+    }
+
+    /// The core fix: Terax must be a recognized terminal, otherwise its bundle id
+    /// falls through to detectRunningTerminal() and the click jumps to the wrong app.
+    func testTeraxIsRecognizedTerminal() {
+        XCTAssertTrue(
+            TerminalActivator.knownTerminals.contains { $0.bundleId == "app.crynta.terax" },
+            "Terax must be in knownTerminals so click-to-jump routes to it deterministically"
+        )
+    }
+
+    /// Terax hosts a CLI; it is not an IDE integrated terminal and not native-app mode.
+    func testTeraxClaudeSessionClassification() {
+        let session = makeSession(termBundleId: "app.crynta.terax", source: "claude")
+        XCTAssertFalse(session.isIDETerminal)
+        XCTAssertFalse(session.isNativeAppMode)
+    }
+}


### PR DESCRIPTION
## Problem

Clicking a session card for an agent running in **Terax** (`app.crynta.terax`) does not jump to the terminal. Terax was not in `knownTerminals`, and it exports no `TERM_PROGRAM`, so `TerminalActivator.activate(...)` fell through to `detectRunningTerminal()` and misrouted the click to whatever other terminal happened to be running (or the `Terminal.app` default). The card shows the correct icon only because the icon is looked up generically from the bundle id.

## Fix

Register Terax and add an explicit app-level activation branch, mirroring the existing **Superset** handling:

- `knownTerminals` gains `("Terax", "app.crynta.terax")` (also relaxed `private` → internal `static`, matching `sourceToNativeAppBundleId`, so support tests can assert recognition).
- A new branch after the Superset block routes `app.crynta.terax` (or `lower == "terax"`) to `activateByBundleId`.

Terax is a single-window app whose tabs are drawn inside a webview. It ships **no** URL scheme, AppleScript dictionary, focus CLI, or native tab shortcut, and its tabs are **not** exposed in the accessibility tree — verified locally (`file` shows a native binary, empty `CFBundleURLTypes`, no `.sdef`, no tab menu items, empty AX tab/radio query). So per-tab precision is impossible upstream; bringing the window forward is the ceiling, exactly as Superset does.

## Verification

- New `TeraxSupportTests` asserts Terax is recognized and that a Terax claude session is not `isIDETerminal` / not `isNativeAppMode`.
- Built the app from this branch and swapped it into a live install: the click path now brings Terax to the front where before it misrouted. `activateByBundleId("app.crynta.terax")` (LaunchServices) was confirmed to foreground Terax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
