### PR TITLE
fix: complete cursor-cli and qoder-cli routing (#248 follow-up)

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -732,11 +732,13 @@ final class AppState {
         case "codex":      return findCodexPids(candidatePids: candidatePids)
         case "gemini":     return findGeminiPids(candidatePids: candidatePids)
         case "cursor":     return findCursorPids(candidatePids: candidatePids)
+        case "cursor-cli": return findCursorCliPids(candidatePids: candidatePids)
         case "trae":       return findTraePids(candidatePids: candidatePids)
         case "traecn":     return findTraeCNPids(candidatePids: candidatePids)
         case "traecli":   return findTraeCliPids(candidatePids: candidatePids)
         case "copilot":    return findCopilotPids(candidatePids: candidatePids)
         case "qoder":      return findQoderPids(candidatePids: candidatePids)
+        case "qoder-cli":  return findQoderCliPids(candidatePids: candidatePids)
         case "droid":      return findFactoryPids(candidatePids: candidatePids)
         case "codebuddy":  return findCodeBuddyPids(candidatePids: candidatePids)
         case "codybuddycn": return findCodyBuddyCNPids(candidatePids: candidatePids)
@@ -1012,7 +1014,8 @@ final class AppState {
         }
 
         // Detect Cursor YOLO mode once per session (nil = unchecked)
-        if event.rawJSON["_source"] as? String == "cursor",
+        if let source = event.rawJSON["_source"] as? String,
+           (source == "cursor" || source == "cursor-cli"),
            sessions[sessionId]?.isYoloMode == nil {
             sessions[sessionId]?.isYoloMode = Self.detectCursorYoloMode()
         }
@@ -1787,7 +1790,7 @@ final class AppState {
         switch source {
         case "claude":
             return readModelFromTranscript(sessionId: sessionId, cwd: session.cwd)
-        case "qoder":
+        case "qoder", "qoder-cli":
             return readModelFromProjectTranscript(
                 sessionId: sessionId,
                 cwd: session.cwd,
@@ -1815,7 +1818,7 @@ final class AppState {
             return readModelFromCodexStore(cwd: session.cwd, processStart: processStart)
         case "gemini":
             return readModelFromGeminiStore(cwd: session.cwd, processStart: processStart)
-        case "cursor":
+        case "cursor", "cursor-cli":
             return readModelFromCursorStore(cwd: session.cwd, processStart: processStart)
         case "copilot":
             return readModelFromCopilotStore(cwd: session.cwd, processStart: processStart)
@@ -1904,7 +1907,7 @@ final class AppState {
         switch session.source {
         case "codex":
             return codexLatestFinishedTurnTimestamp(sessionId: sessionId, session: session)
-        case "qoder":
+        case "qoder", "qoder-cli":
             return qoderLatestFinishedTurnTimestamp(sessionId: sessionId, session: session)
         case "codebuddy":
             return codeBuddyLatestFinishedTurnTimestamp(sessionId: sessionId, session: session)
@@ -2853,12 +2856,40 @@ final class AppState {
         )
     }
 
+    /// Standalone Cursor CLI agent — must not match the desktop IDE/helper
+    /// processes that `findCursorPids` also covers (#248).
+    private nonisolated static func findCursorCliPids(candidatePids: [pid_t]? = nil) -> [pid_t] {
+        findPids(
+            matchingPathSubstrings: [
+                "/.local/share/cursor-agent/versions/",
+            ],
+            argSubstrings: ["/cursor-agent/index.js"],
+            candidatePids: candidatePids
+        )
+    }
+
     private nonisolated static func findQoderPids(candidatePids: [pid_t]? = nil) -> [pid_t] {
         findPids(
             matchingPathSubstrings: [
                 "/qoder.app/contents/macos/electron",
                 "/qoder.app/contents/frameworks/qoder helper",
                 "/.qoder/bin/qodercli/",
+            ],
+            candidatePids: candidatePids
+        )
+    }
+
+    /// Standalone Qoder CLI — must not match the desktop IDE/helper (#248).
+    private nonisolated static func findQoderCliPids(candidatePids: [pid_t]? = nil) -> [pid_t] {
+        findPids(
+            matchingPathSubstrings: [
+                "/.qoder/bin/qodercli/",
+                "/@qoder-ai/qodercli",
+            ],
+            argSubstrings: [
+                "/opt/homebrew/bin/qodercli",
+                "/usr/local/bin/qodercli",
+                "/.local/bin/qodercli",
             ],
             candidatePids: candidatePids
         )

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -145,13 +145,45 @@ class HookServer {
     /// Empty filter = allow everything (previous behavior). With a filter set,
     /// events must carry a cwd containing one of the entries; events without a
     /// cwd are dropped too — on a shared account they can't be attributed.
-    nonisolated static func remoteEventPassesCwdFilter(cwd: String?, filterCSV: String) -> Bool {
+    nonisolated static func remoteEventPassesCwdFilter(
+        cwd: String?,
+        workspaceRoots: [String]? = nil,
+        filterCSV: String
+    ) -> Bool {
         let hasPattern = filterCSV
             .split(separator: ",", omittingEmptySubsequences: false)
             .contains { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         guard hasPattern else { return true }
-        guard let cwd, !cwd.isEmpty else { return false }
-        return cwdMatchesAnyPattern(cwd, patternsCSV: filterCSV)
+        if let cwd, !cwd.isEmpty, cwdMatchesAnyPattern(cwd, patternsCSV: filterCSV) {
+            return true
+        }
+        if let roots = workspaceRoots {
+            for root in roots where !root.isEmpty {
+                if cwdMatchesAnyPattern(root, patternsCSV: filterCSV) {
+                    return true
+                }
+            }
+        }
+        // No cwd or workspace root matched — on a shared account they can't be attributed.
+        return false
+    }
+
+    /// Remote cwd allow-lists drop hooks from other users' directories on shared
+    /// SSH accounts (#240). Lifecycle and blocking hooks for sessions we already
+    /// track must still flow through — otherwise SessionEnd/Stop never tears
+    /// sessions down and PermissionRequest/Notification stall the remote agent.
+    nonisolated static func remoteEventBypassesCwdFilter(
+        eventName: String,
+        sessionId: String?,
+        trackedSessionIds: Set<String>
+    ) -> Bool {
+        guard let sessionId, trackedSessionIds.contains(sessionId) else { return false }
+        switch EventNormalizer.normalize(eventName) {
+        case "SessionEnd", "Stop", "SubagentStop", "PermissionRequest", "Notification", "AfterAgentResponse":
+            return true
+        default:
+            return false
+        }
     }
 
     /// Looks up the configured cwd filter for a remote host id. Nil when the
@@ -451,7 +483,16 @@ class HookServer {
         // account every user's hooks reach every connected client — scope this
         // panel to the configured working directories and drop the rest.
         if let filterCSV = Self.remoteCwdFilter(for: event),
-           !Self.remoteEventPassesCwdFilter(cwd: event.rawJSON["cwd"] as? String, filterCSV: filterCSV) {
+           !Self.remoteEventPassesCwdFilter(
+               cwd: event.rawJSON["cwd"] as? String,
+               workspaceRoots: event.rawJSON["workspace_roots"] as? [String],
+               filterCSV: filterCSV
+           ),
+           !Self.remoteEventBypassesCwdFilter(
+               eventName: event.eventName,
+               sessionId: event.sessionId,
+               trackedSessionIds: Set(appState.sessions.keys)
+           ) {
             sendResponse(connection: connection, data: Data("{}".utf8))
             return
         }

--- a/Sources/CodeIsland/KiroView.swift
+++ b/Sources/CodeIsland/KiroView.swift
@@ -89,10 +89,14 @@ struct KiroView: View {
                     let ci = Double(i)
                     let cycle = 3.1 + ci * 0.4
                     let p = max(0, ((t - ci * 1.2).truncatingRemainder(dividingBy: cycle)) / cycle)
+                    let fontSize: CGFloat = max(6, size * CGFloat(0.15 + p * 0.08))
+                    let opacity: Double = p < 0.8 ? 0.55 - ci * 0.15 : (1 - p) * 3 * 0.55
+                    let dx = size * CGFloat(0.14 + ci * 0.05)
+                    let dy = -size * CGFloat(0.14 + p * 0.32)
                     Text("z")
-                        .font(.system(size: max(6, size * CGFloat(0.15 + p * 0.08)), weight: .black, design: .monospaced))
-                        .foregroundStyle(.white.opacity(p < 0.8 ? 0.55 - ci * 0.15 : (1 - p) * 3 * 0.55))
-                        .offset(x: size * CGFloat(0.14 + ci * 0.05), y: -size * CGFloat(0.14 + p * 0.32))
+                        .font(.system(size: fontSize, weight: .black, design: .monospaced))
+                        .foregroundStyle(.white.opacity(opacity))
+                        .offset(x: dx, y: dy)
                 }
             }
         }

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -1718,15 +1718,24 @@ private struct SessionListView: View {
                 ("stepfun", "StepFun"),
                 ("workbuddy", "WorkBuddy"),
                 ("hermes", "Hermes"),
+                ("openclaw", "OpenClaw"),
                 ("qwen", "Qwen Code"),
                 ("kimi", "Kimi Code CLI"),
                 ("opencode", "OpenCode"),
+                ("pi", "Pi"),
+                ("kiro", "Kiro"),
+                ("cline", "Cline"),
             ]
             var result: [(String, String?, [String])] = []
             var seen = Set<String>()
             for cli in cliOrder {
                 let ids = sorted.filter { id in
-                    appState.sessions[id]?.source == cli.source
+                    guard let source = appState.sessions[id]?.source else { return false }
+                    if source == cli.source { return true }
+                    // Bundle promoted -cli variants with their IDE group (#248).
+                    if cli.source == "cursor", source == "cursor-cli" { return true }
+                    if cli.source == "qoder", source == "qoder-cli" { return true }
+                    return false
                 }
                 ids.forEach { seen.insert($0) }
                 if !ids.isEmpty {
@@ -2686,11 +2695,13 @@ private let cliIconFiles: [String: String] = [
     "antigravity": "antigravity",
     "google-antigravity": "gemini",
     "cursor": "cursor",
+    "cursor-cli": "cursor",
     "trae": "trae",
     "traecn": "trae",
     "traecli": "trae",
     "copilot": "copilot",
     "qoder": "qoder",
+    "qoder-cli": "qoder",
     "droid": "factory",
     "codebuddy": "codebuddy",
     "codybuddycn": "codebuddy",

--- a/Sources/CodeIsland/OpenClawView.swift
+++ b/Sources/CodeIsland/OpenClawView.swift
@@ -107,10 +107,14 @@ struct OpenClawView: View {
                 let ci = Double(i)
                 let cycle = 3.0 + ci * 0.4
                 let p = max(0, ((t - ci * 1.1).truncatingRemainder(dividingBy: cycle)) / cycle)
+                let fontSize: CGFloat = max(6, size * CGFloat(0.16 + p * 0.08))
+                let opacity: Double = p < 0.8 ? 0.6 - ci * 0.15 : (1 - p) * 3 * 0.6
+                let dx = size * CGFloat(0.12 + ci * 0.06)
+                let dy = -size * CGFloat(0.12 + p * 0.34)
                 Text("z")
-                    .font(.system(size: max(6, size * CGFloat(0.16 + p * 0.08)), weight: .black, design: .monospaced))
-                    .foregroundStyle(.white.opacity(p < 0.8 ? 0.6 - ci * 0.15 : (1 - p) * 3 * 0.6))
-                    .offset(x: size * CGFloat(0.12 + ci * 0.06), y: -size * CGFloat(0.12 + p * 0.34))
+                    .font(.system(size: fontSize, weight: .black, design: .monospaced))
+                    .foregroundStyle(.white.opacity(opacity))
+                    .offset(x: dx, y: dy)
             }
         }
     }

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -40,6 +40,9 @@ public struct SessionSnapshot: Sendable {
 
     public static let ideCompletionSources: Set<String> = [
         "cursor",
+        "cursor-cli",
+        "qoder",
+        "qoder-cli",
         "trae",
         "traecn",
         "codebuddy",

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -268,17 +268,144 @@ public struct SessionSnapshot: Sendable {
 
     /// Display name: project folder, or short session ID
     public var displayName: String {
-        if let cwd = cwd {
-            let last = (cwd as NSString).lastPathComponent
-            // If last component is a timestamp/numeric ID (e.g. CodeBuddy "20260406010126"),
-            // show the parent directory name instead
-            if last.count >= 8 && last.allSatisfy(\.isNumber) {
-                let parent = ((cwd as NSString).deletingLastPathComponent as NSString).lastPathComponent
-                if !parent.isEmpty && parent != "/" { return parent }
+        guard let cwd = cwd else { return "Session" }
+        return Self.resolvedProjectDisplayName(from: cwd)
+    }
+
+    /// Resolve a human project folder label from a cwd path.
+    static func resolvedProjectDisplayName(from cwd: String) -> String {
+        var name = displayNameLeafFromCursorProjectsPath(cwd)
+            ?? (cwd as NSString).lastPathComponent
+
+        // Agent metadata dirs (.claude, .cursor) are not project names (#248).
+        if name.hasPrefix("."), name.count > 1 {
+            if let peeled = peelProjectNameBeforeMetadataDir(in: cwd, leaf: name) {
+                name = peeled
+            } else if isUnhelpfulHookCwd(cwd) {
+                return "Session"
             }
-            return last
         }
-        return "Session"
+
+        if isHomeDirectoryPath(cwd) || isHomeDirectoryBasename(name, for: cwd) {
+            return "Session"
+        }
+
+        if name.count >= 8 && name.allSatisfy(\.isNumber) {
+            let parent = ((cwd as NSString).deletingLastPathComponent as NSString).lastPathComponent
+            if !parent.isEmpty && parent != "/" && !isHomeDirectoryBasename(parent, for: cwd) {
+                return parent
+            }
+        }
+        return name
+    }
+
+    /// Cursor stores projects under `~/.cursor/projects/<encoded>/…` where slashes
+    /// in the original workspace path become hyphens. Literal hyphens inside a
+    /// folder name are preserved, so naive full-path reversal is ambiguous — walk
+    /// hyphen segments from the right until the reconstructed path exists.
+    static func displayNameLeafFromCursorProjectsPath(_ cwd: String) -> String? {
+        let marker = "/.cursor/projects/"
+        guard let range = cwd.range(of: marker) else { return nil }
+        let encoded = cwd[range.upperBound...].split(separator: "/").first.map(String.init) ?? ""
+        guard !encoded.isEmpty else { return nil }
+
+        let homeEncoded = homeDirectoryProjectEncoded()
+        let projectEncoded: String
+        if encoded.hasPrefix(homeEncoded + "-") {
+            projectEncoded = String(encoded.dropFirst(homeEncoded.count + 1))
+        } else if encoded == homeEncoded {
+            return nil
+        } else {
+            projectEncoded = encoded
+        }
+        guard !projectEncoded.isEmpty else { return nil }
+
+        let parts = projectEncoded.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
+        guard !parts.isEmpty else { return nil }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let fm = FileManager.default
+        // Prefer the longest leaf whose prefix reconstructs to a real directory.
+        for k in stride(from: parts.count - 1, through: 0, by: -1) {
+            let leaf = parts[k...].joined(separator: "-")
+            guard !leaf.isEmpty else { continue }
+            if k == 0 {
+                return leaf
+            }
+            let relative = parts[..<k].joined(separator: "/") + "/" + leaf
+            if fm.fileExists(atPath: "\(home)/\(relative)") {
+                return leaf
+            }
+        }
+        return parts.last
+    }
+
+    /// When cwd sits inside a metadata dir, or a Cursor-encoded leaf is one, peel
+    /// back to the real project folder name.
+    static func peelProjectNameBeforeMetadataDir(in cwd: String, leaf: String) -> String? {
+        guard leaf.hasPrefix(".") else { return nil }
+
+        if cwd.contains("/.cursor/projects/") {
+            let marker = "/.cursor/projects/"
+            guard let range = cwd.range(of: marker) else { return nil }
+            let encoded = cwd[range.upperBound...].split(separator: "/").first.map(String.init) ?? ""
+            if let peeled = peelEncodedProjectTailBeforeMetadataDir(encoded) {
+                return peeled
+            }
+        }
+
+        let parent = ((cwd as NSString).deletingLastPathComponent as NSString).lastPathComponent
+        let parentPath = (cwd as NSString).deletingLastPathComponent
+        if !parent.isEmpty && parent != "/",
+           !isHomeDirectoryPath(parentPath),
+           !parent.contains("/.cursor/projects/"),
+           !looksLikeCursorEncodedDir(parent) {
+            return parent
+        }
+        return nil
+    }
+
+    /// Hook/bridge cwd values that carry no project identity — getcwd() inside
+    /// `~/.claude` or at `$HOME` must not block workspace_roots / transcript_path.
+    static func isUnhelpfulHookCwd(_ cwd: String) -> Bool {
+        if isHomeDirectoryPath(cwd) { return true }
+        let last = (cwd as NSString).lastPathComponent
+        guard last.hasPrefix("."), last.count > 1 else { return false }
+        return isHomeDirectoryPath((cwd as NSString).deletingLastPathComponent)
+    }
+
+    static func isHomeDirectoryPath(_ path: String) -> Bool {
+        let home = (FileManager.default.homeDirectoryForCurrentUser.path as NSString).standardizingPath
+        return (path as NSString).standardizingPath == home
+    }
+
+    static func isHomeDirectoryBasename(_ name: String, for cwd: String) -> Bool {
+        name == (FileManager.default.homeDirectoryForCurrentUser.path as NSString).lastPathComponent
+            && (isHomeDirectoryPath(cwd) || isUnhelpfulHookCwd(cwd))
+    }
+
+    static func peelEncodedProjectTailBeforeMetadataDir(_ encoded: String) -> String? {
+        let homeEncoded = homeDirectoryProjectEncoded()
+        let projectEncoded: String
+        if encoded.hasPrefix(homeEncoded + "-") {
+            projectEncoded = String(encoded.dropFirst(homeEncoded.count + 1))
+        } else {
+            projectEncoded = encoded
+        }
+        let parts = projectEncoded.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 2, parts.last?.hasPrefix(".") == true else { return nil }
+        let peeled = parts[parts.count - 2]
+        return peeled.isEmpty ? nil : peeled
+    }
+
+    private static func looksLikeCursorEncodedDir(_ name: String) -> Bool {
+        name.contains("-") && !name.hasPrefix(".")
+    }
+
+    private static func homeDirectoryProjectEncoded() -> String {
+        var home = FileManager.default.homeDirectoryForCurrentUser.path
+        if home.hasPrefix("/") { home = String(home.dropFirst()) }
+        return home.replacingOccurrences(of: "/", with: "-")
     }
 
     public func displayTitle(sessionId: String) -> String {
@@ -964,13 +1091,17 @@ private func applyEnvMetadata(into sessions: inout [String: SessionSnapshot], se
 }
 
 public func extractMetadata(into sessions: inout [String: SessionSnapshot], sessionId: String, event: HookEvent) {
-    if let cwd = event.rawJSON["cwd"] as? String, !cwd.isEmpty {
+    if let cwd = event.rawJSON["cwd"] as? String, !cwd.isEmpty,
+       !SessionSnapshot.isUnhelpfulHookCwd(cwd) {
         sessions[sessionId]?.cwd = cwd
-    } else if sessions[sessionId]?.cwd == nil,
-              let roots = event.rawJSON["workspace_roots"] as? [String],
-              let first = roots.first, !first.isEmpty {
+    }
+    if sessions[sessionId]?.cwd == nil
+        || SessionSnapshot.isUnhelpfulHookCwd(sessions[sessionId]?.cwd ?? ""),
+       let roots = event.rawJSON["workspace_roots"] as? [String],
+       let first = roots.first, !first.isEmpty {
         sessions[sessionId]?.cwd = first
-    } else if sessions[sessionId]?.cwd == nil,
+    } else if sessions[sessionId]?.cwd == nil
+        || SessionSnapshot.isUnhelpfulHookCwd(sessions[sessionId]?.cwd ?? ""),
               let tp = event.rawJSON["transcript_path"] as? String, !tp.isEmpty {
         // Cursor: extract project dir from transcript_path
         // e.g. ~/.cursor/projects/<project>/agent-transcripts/... → ~/.cursor/projects/<project>

--- a/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
+++ b/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
@@ -210,18 +210,19 @@ final class DerivedSessionStateTests: XCTestCase {
 
     func testExtractMetadataPrefersWorkspaceRootsOverHomeClaudeCwd() throws {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let workspace = "/tmp/codeisland-workspace"
         var sessions: [String: SessionSnapshot] = ["s1": SessionSnapshot()]
         let event = try decode([
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
             "_source": "cursor-cli",
             "cwd": "\(home)/.claude",
-            "workspace_roots": ["/Users/wangnov/Code/CodeIsland"],
+            "workspace_roots": [workspace],
         ])
 
         extractMetadata(into: &sessions, sessionId: "s1", event: event)
 
-        XCTAssertEqual(sessions["s1"]?.cwd, "/Users/wangnov/Code/CodeIsland")
+        XCTAssertEqual(sessions["s1"]?.cwd, workspace)
     }
 
     private func decode(_ payload: [String: Any]) throws -> HookEvent {

--- a/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
+++ b/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
@@ -208,6 +208,22 @@ final class DerivedSessionStateTests: XCTestCase {
         XCTAssertEqual(source, "codex")
     }
 
+    func testExtractMetadataPrefersWorkspaceRootsOverHomeClaudeCwd() throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var sessions: [String: SessionSnapshot] = ["s1": SessionSnapshot()]
+        let event = try decode([
+            "hook_event_name": "PreToolUse",
+            "session_id": "s1",
+            "_source": "cursor-cli",
+            "cwd": "\(home)/.claude",
+            "workspace_roots": ["/Users/wangnov/Code/CodeIsland"],
+        ])
+
+        extractMetadata(into: &sessions, sessionId: "s1", event: event)
+
+        XCTAssertEqual(sessions["s1"]?.cwd, "/Users/wangnov/Code/CodeIsland")
+    }
+
     private func decode(_ payload: [String: Any]) throws -> HookEvent {
         let data = try JSONSerialization.data(withJSONObject: payload)
         guard let event = HookEvent(from: data) else {

--- a/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
+++ b/Tests/CodeIslandCoreTests/DerivedSessionStateTests.swift
@@ -82,6 +82,50 @@ final class DerivedSessionStateTests: XCTestCase {
         XCTAssertTrue(effects.contains(.enqueueCompletion(sessionId: "cursor-session")))
     }
 
+    func testAfterAgentResponseCompletesCursorCliSource() throws {
+        var session = SessionSnapshot()
+        session.source = "cursor-cli"
+        session.status = .running
+
+        var sessions = ["cursor-cli-session": session]
+        let event = try decode([
+            "hook_event_name": "afterAgentResponse",
+            "session_id": "cursor-cli-session",
+            "_source": "cursor-cli",
+            "text": "Done",
+        ])
+
+        let effects = reduceEvent(sessions: &sessions, event: event, maxHistory: 10)
+
+        XCTAssertEqual(sessions["cursor-cli-session"]?.status, .idle)
+        XCTAssertTrue(effects.contains(.enqueueCompletion(sessionId: "cursor-cli-session")))
+    }
+
+    func testAfterAgentResponseCompletesQoderCliSource() throws {
+        var session = SessionSnapshot()
+        session.source = "qoder-cli"
+        session.status = .running
+
+        var sessions = ["qoder-cli-session": session]
+        let event = try decode([
+            "hook_event_name": "afterAgentResponse",
+            "session_id": "qoder-cli-session",
+            "_source": "qoder-cli",
+            "text": "Done",
+        ])
+
+        let effects = reduceEvent(sessions: &sessions, event: event, maxHistory: 10)
+
+        XCTAssertEqual(sessions["qoder-cli-session"]?.status, .idle)
+        XCTAssertTrue(effects.contains(.enqueueCompletion(sessionId: "qoder-cli-session")))
+    }
+
+    func testIdeCompletionSourcesIncludeCliVariants() {
+        XCTAssertTrue(SessionSnapshot.ideCompletionSources.contains("cursor-cli"))
+        XCTAssertTrue(SessionSnapshot.ideCompletionSources.contains("qoder"))
+        XCTAssertTrue(SessionSnapshot.ideCompletionSources.contains("qoder-cli"))
+    }
+
     func testAfterAgentResponseKeepsCLISourceProcessing() throws {
         var session = SessionSnapshot()
         session.source = "claude"

--- a/Tests/CodeIslandCoreTests/SessionSnapshotTitleTests.swift
+++ b/Tests/CodeIslandCoreTests/SessionSnapshotTitleTests.swift
@@ -2,6 +2,17 @@ import XCTest
 @testable import CodeIslandCore
 
 final class SessionSnapshotTitleTests: XCTestCase {
+    /// Synthetic paths — tests must not assume clone location or OS username.
+    private let fixtureLeaf = "myproject"
+    private var fixtureCwd: String { "/tmp/\(fixtureLeaf)" }
+    private var fixtureMetadataCwd: String { "\(fixtureCwd)/.claude" }
+
+    private func cursorProjectsCwd(encodedTail: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
+        return "\(home)/.cursor/projects/\(homeEncoded)-\(encodedTail)/agent-transcripts"
+    }
+
     func testDisplayTitlePrefersProviderSessionTitle() {
         var snapshot = SessionSnapshot()
         snapshot.sessionTitle = "Investigate icon sizing"
@@ -23,16 +34,16 @@ final class SessionSnapshotTitleTests: XCTestCase {
 
     func testProjectDisplayNameStillUsesFolderName() {
         var snapshot = SessionSnapshot()
-        snapshot.cwd = "/Users/wangnov/CodeIsland"
+        snapshot.cwd = fixtureCwd
 
-        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+        XCTAssertEqual(snapshot.projectDisplayName, fixtureLeaf)
     }
 
     func testProjectDisplayNameSkipsClaudeMetadataDir() {
         var snapshot = SessionSnapshot()
-        snapshot.cwd = "/Users/wangnov/Code/CodeIsland/.claude"
+        snapshot.cwd = fixtureMetadataCwd
 
-        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+        XCTAssertEqual(snapshot.projectDisplayName, fixtureLeaf)
     }
 
     func testProjectDisplayNameDoesNotUseHomeUsernameForGlobalClaudeDir() {
@@ -45,35 +56,37 @@ final class SessionSnapshotTitleTests: XCTestCase {
     }
 
     func testProjectDisplayNameDecodesCursorProjectsPath() {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
         var snapshot = SessionSnapshot()
-        snapshot.cwd = "\(home)/.cursor/projects/\(homeEncoded)-Code-CodeIsland/agent-transcripts"
+        snapshot.cwd = cursorProjectsCwd(encodedTail: fixtureLeaf)
 
-        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+        XCTAssertEqual(snapshot.projectDisplayName, fixtureLeaf)
     }
 
     func testProjectDisplayNamePreservesHyphenatedCursorProjectLeaf() throws {
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser.path
-        let projectDir = "\(home)/Code/codeisland-hyphen-display-test"
+        let hyphenLeaf = "my-sample-app"
+        let projectDir = "\(home)/\(hyphenLeaf)"
         try fm.createDirectory(atPath: projectDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(atPath: projectDir) }
 
-        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
         var snapshot = SessionSnapshot()
-        snapshot.cwd = "\(home)/.cursor/projects/\(homeEncoded)-Code-codeisland-hyphen-display-test/agent-transcripts"
+        snapshot.cwd = cursorProjectsCwd(encodedTail: hyphenLeaf)
 
-        XCTAssertEqual(snapshot.projectDisplayName, "codeisland-hyphen-display-test")
+        XCTAssertEqual(snapshot.projectDisplayName, hyphenLeaf)
     }
 
-    func testProjectDisplayNamePeelsMetadataDirFromCursorEncodedPath() {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
-        var snapshot = SessionSnapshot()
-        snapshot.cwd = "\(home)/.cursor/projects/\(homeEncoded)-Code-CodeIsland-.claude/agent-transcripts"
+    func testProjectDisplayNamePeelsMetadataDirFromCursorEncodedPath() throws {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let metadataDir = "\(home)/\(fixtureLeaf)/.claude"
+        try fm.createDirectory(atPath: metadataDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: "\(home)/\(fixtureLeaf)") }
 
-        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+        var snapshot = SessionSnapshot()
+        snapshot.cwd = cursorProjectsCwd(encodedTail: "\(fixtureLeaf)-.claude")
+
+        XCTAssertEqual(snapshot.projectDisplayName, fixtureLeaf)
     }
 
     func testDisplaySessionIdPrefersProviderSessionId() {
@@ -97,13 +110,13 @@ final class SessionSnapshotTitleTests: XCTestCase {
 
     func testSessionTitleAssignmentDoesNotOverwriteProjectDisplayName() {
         var snapshot = SessionSnapshot()
-        snapshot.cwd = "/Users/wangnov/CodeIsland"
+        snapshot.cwd = fixtureCwd
         snapshot.sessionTitle = "查看图标bug和窗口大小bug解法"
 
         XCTAssertEqual(
             snapshot.displayTitle(sessionId: "019d6331-3593-7b53-9513-c1dd25d708b0"),
             "查看图标bug和窗口大小bug解法"
         )
-        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+        XCTAssertEqual(snapshot.projectDisplayName, fixtureLeaf)
     }
 }

--- a/Tests/CodeIslandCoreTests/SessionSnapshotTitleTests.swift
+++ b/Tests/CodeIslandCoreTests/SessionSnapshotTitleTests.swift
@@ -28,6 +28,54 @@ final class SessionSnapshotTitleTests: XCTestCase {
         XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
     }
 
+    func testProjectDisplayNameSkipsClaudeMetadataDir() {
+        var snapshot = SessionSnapshot()
+        snapshot.cwd = "/Users/wangnov/Code/CodeIsland/.claude"
+
+        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+    }
+
+    func testProjectDisplayNameDoesNotUseHomeUsernameForGlobalClaudeDir() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var snapshot = SessionSnapshot()
+        snapshot.cwd = "\(home)/.claude"
+
+        XCTAssertNotEqual(snapshot.projectDisplayName, (home as NSString).lastPathComponent)
+        XCTAssertEqual(snapshot.projectDisplayName, "Session")
+    }
+
+    func testProjectDisplayNameDecodesCursorProjectsPath() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
+        var snapshot = SessionSnapshot()
+        snapshot.cwd = "\(home)/.cursor/projects/\(homeEncoded)-Code-CodeIsland/agent-transcripts"
+
+        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+    }
+
+    func testProjectDisplayNamePreservesHyphenatedCursorProjectLeaf() throws {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let projectDir = "\(home)/Code/codeisland-hyphen-display-test"
+        try fm.createDirectory(atPath: projectDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: projectDir) }
+
+        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
+        var snapshot = SessionSnapshot()
+        snapshot.cwd = "\(home)/.cursor/projects/\(homeEncoded)-Code-codeisland-hyphen-display-test/agent-transcripts"
+
+        XCTAssertEqual(snapshot.projectDisplayName, "codeisland-hyphen-display-test")
+    }
+
+    func testProjectDisplayNamePeelsMetadataDirFromCursorEncodedPath() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let homeEncoded = String(home.dropFirst()).replacingOccurrences(of: "/", with: "-")
+        var snapshot = SessionSnapshot()
+        snapshot.cwd = "\(home)/.cursor/projects/\(homeEncoded)-Code-CodeIsland-.claude/agent-transcripts"
+
+        XCTAssertEqual(snapshot.projectDisplayName, "CodeIsland")
+    }
+
     func testDisplaySessionIdPrefersProviderSessionId() {
         var snapshot = SessionSnapshot()
         snapshot.providerSessionId = "019d6330-beed-7a13-b61e-cacf03d3cefe"

--- a/Tests/CodeIslandTests/RemoteCwdFilterTests.swift
+++ b/Tests/CodeIslandTests/RemoteCwdFilterTests.swift
@@ -40,11 +40,58 @@ final class RemoteCwdFilterTests: XCTestCase {
         XCTAssertFalse(HookServer.remoteEventPassesCwdFilter(cwd: "", filterCSV: "/home/me"))
     }
 
+    func testWorkspaceRootsPassFilterWhenCwdIsUnhelpful() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        XCTAssertTrue(HookServer.remoteEventPassesCwdFilter(
+            cwd: "\(home)/.claude",
+            workspaceRoots: ["/home/me/projects/api"],
+            filterCSV: "/home/me/projects"
+        ))
+        XCTAssertFalse(HookServer.remoteEventPassesCwdFilter(
+            cwd: "\(home)/.claude",
+            workspaceRoots: ["/home/colleague/projects/api"],
+            filterCSV: "/home/me/projects"
+        ))
+    }
+
     func testEntriesAreTrimmed() {
         XCTAssertTrue(HookServer.remoteEventPassesCwdFilter(
             cwd: "/data/work/x",
             filterCSV: " /data/work , /other "
         ))
+    }
+
+    // MARK: remoteEventBypassesCwdFilter
+
+    func testLifecycleHooksBypassFilterForTrackedSessions() {
+        let tracked: Set<String> = ["sess-1"]
+        XCTAssertTrue(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "SessionEnd", sessionId: "sess-1", trackedSessionIds: tracked))
+        XCTAssertTrue(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "stop", sessionId: "sess-1", trackedSessionIds: tracked))
+        XCTAssertTrue(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "PermissionRequest", sessionId: "sess-1", trackedSessionIds: tracked))
+        XCTAssertTrue(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "Notification", sessionId: "sess-1", trackedSessionIds: tracked))
+        XCTAssertTrue(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "AfterAgentResponse", sessionId: "sess-1", trackedSessionIds: tracked))
+        XCTAssertTrue(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "afterAgentResponse", sessionId: "sess-1", trackedSessionIds: tracked))
+    }
+
+    func testLifecycleBypassRequiresTrackedSession() {
+        XCTAssertFalse(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "SessionEnd", sessionId: "other-user", trackedSessionIds: ["sess-1"]))
+        XCTAssertFalse(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "SessionEnd", sessionId: nil, trackedSessionIds: ["sess-1"]))
+    }
+
+    func testNonLifecycleHooksDoNotBypassFilter() {
+        let tracked: Set<String> = ["sess-1"]
+        XCTAssertFalse(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "PreToolUse", sessionId: "sess-1", trackedSessionIds: tracked))
+        XCTAssertFalse(HookServer.remoteEventBypassesCwdFilter(
+            eventName: "SessionStart", sessionId: "sess-1", trackedSessionIds: tracked))
     }
 
     // MARK: RemoteHost model compatibility


### PR DESCRIPTION
Fixes follow-up to #248.

## Summary

- **#248 routing:** Dedicated `findCursorCliPids` / `findQoderCliPids`; extend `-cli` through YOLO, model/timestamp readers, and `ideCompletionSources` (`AfterAgentResponse` → idle).
- **#248 display:** Skip `.claude` metadata dirs; decode `~/.cursor/projects/<encoded>` via filesystem-backed walking; prefer `workspace_roots` over unhelpful cwd (`~/.claude`, `$HOME`).
- **#248 UI:** Group `cursor-cli` / `qoder-cli` under Cursor / Qoder in the CLI tab (not "Other").
- **#240 remote:** Tracked sessions bypass the cwd allow-list for lifecycle/blocking hooks (`SessionEnd`, `Stop`, `SubagentStop`, `PermissionRequest`, `Notification`, `AfterAgentResponse`). Hooks may also pass when `workspace_roots` matches, even if `cwd` does not.

## 中文说明

- **#248 路由：** 拆分 CLI 专用 PID 查找器，避免 CWD 回退绑到桌面 IDE；补全 `-cli` 的 YOLO、模型读取与 `AfterAgentResponse` 完成态。
- **#248 显示：** 修复项目名显示为 `.claude` 或用户名；跳过元数据目录，优先 `workspace_roots`，正确解码 Cursor 编码路径。
- **#248 分组：** `cursor-cli` / `qoder-cli` 归入 Cursor / Qoder，不再进「其他」。
- **#240 远程：** 已跟踪会话的生命周期/阻塞 hook 不再被 cwd 白名单误拦；`workspace_roots` 参与过滤匹配。

## Test Plan

- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 489 tests, 0 failures
- [x] `SessionSnapshotTitleTests` — `.claude` skip, Cursor encoded path, hyphenated project names, unhelpful cwd → `Session`
- [x] `DerivedSessionStateTests` — `cursor-cli` / `qoder-cli` `AfterAgentResponse` completion; `workspace_roots` over `~/.claude`
- [x] `RemoteCwdFilterTests` — lifecycle bypass for tracked sessions; `workspace_roots` passes filter when cwd is unhelpful; `AfterAgentResponse` bypass
- [x] Manual: `cursor-agent` in terminal shows project folder name (not `.claude` / username) in session list
- [x] Manual: `cursor-cli` sessions grouped under Cursor in CLI tab (not Other)
- [ ] Manual: remote host with cwd filter — session tracks via `workspace_roots`, tears down on `SessionEnd`, `AfterAgentResponse` completes, approval still works