### PR TITLE
修复：智能抑制下 OMP 提问卡片无法操作

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -787,6 +787,13 @@ final class AppState {
         return !isTerminalFrontmost(session)
     }
 
+    private func shouldAutoOpenQuestionSurface(for event: HookEvent) -> Bool {
+        // AskUserQuestion holds the provider/CLI until its continuation resolves,
+        // so there is no parallel terminal prompt for Smart Suppress to defer to.
+        if event.toolName == "AskUserQuestion" { return true }
+        return shouldAutoOpenPendingSurface(for: event.sessionId ?? "default")
+    }
+
     private func showCompletion(_ sessionId: String) {
         // Fast path: terminal not even frontmost — show immediately
         guard shouldSuppressAppLevel(for: sessionId) else {
@@ -1465,7 +1472,7 @@ final class AppState {
 
         if questionQueue.count == 1 {
             activeSessionId = sessionId
-            if shouldAutoOpenPendingSurface(for: sessionId) {
+            if shouldAutoOpenQuestionSurface(for: event) {
                 withAnimation(NotchAnimation.open) {
                     surface = .questionCard(sessionId: sessionId)
                 }
@@ -1711,7 +1718,7 @@ final class AppState {
         } else if let next = questionQueue.first {
             let sid = next.event.sessionId ?? "default"
             activeSessionId = sid
-            if shouldAutoOpenPendingSurface(for: sid) {
+            if shouldAutoOpenQuestionSurface(for: next.event) {
                 surface = .questionCard(sessionId: sid)
             }
             return true

--- a/Tests/CodeIslandTests/AppStateQuestionFlowTests.swift
+++ b/Tests/CodeIslandTests/AppStateQuestionFlowTests.swift
@@ -1,9 +1,25 @@
 import XCTest
+import AppKit
 @testable import CodeIsland
 import CodeIslandCore
 
 @MainActor
 final class AppStateQuestionFlowTests: XCTestCase {
+    private var savedSmartSuppress: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedSmartSuppress = UserDefaults.standard.object(forKey: SettingsKey.smartSuppress)
+    }
+
+    override func tearDown() {
+        if let savedSmartSuppress {
+            UserDefaults.standard.set(savedSmartSuppress, forKey: SettingsKey.smartSuppress)
+        } else {
+            UserDefaults.standard.removeObject(forKey: SettingsKey.smartSuppress)
+        }
+        super.tearDown()
+    }
 
     // MARK: - Multi-question answers
 
@@ -69,6 +85,105 @@ final class AppStateQuestionFlowTests: XCTestCase {
         let responseData = await responseTask.value
         let answers = try extractAnswers(from: responseData)
         XCTAssertEqual(answers["你希望我主要使用哪种语言回复？"] as? String, "中文")
+    }
+
+    func testAskUserQuestionOpensQuestionCardWhenSmartSuppressSeesGhosttyFrontmost() async throws {
+        UserDefaults.standard.set(true, forKey: SettingsKey.smartSuppress)
+        let appState = AppState()
+        let sessionId = "s-smart-question"
+        var session = SessionSnapshot()
+        session.termApp = "Ghostty"
+        session.termBundleId = try XCTUnwrap(NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+        appState.sessions[sessionId] = session
+        XCTAssertFalse(appState.shouldAutoOpenPendingSurface(for: sessionId), "test setup must model Smart Suppress considering the Ghostty-backed session frontmost")
+
+        let event = try makeAskUserQuestionEvent(
+            sessionId: sessionId,
+            questions: [
+                question(header: "继续吗", text: "需要用户确认下一步吗？", options: ["继续", "停止"])
+            ]
+        )
+
+        let responseTask = Task<Data, Never> {
+            await withCheckedContinuation { continuation in
+                appState.handleAskUserQuestion(event, continuation: continuation)
+            }
+        }
+
+        await Task.yield()
+        XCTAssertEqual(appState.questionQueue.count, 1)
+        let surfaceAfterRequest = appState.surface
+
+        appState.skipQuestion()
+        _ = await responseTask.value
+
+        XCTAssertEqual(
+            surfaceAfterRequest,
+            .questionCard(sessionId: sessionId),
+            "AskUserQuestion must open its card even when Smart Suppress considers the Ghostty-backed terminal frontmost; otherwise OMP waits on CodeIsland while the native terminal dialog is blocked."
+        )
+    }
+
+    func testAskUserQuestionQueueOpensNextQuestionCardWhenSmartSuppressSeesGhosttyFrontmost() async throws {
+        UserDefaults.standard.set(true, forKey: SettingsKey.smartSuppress)
+        let appState = AppState()
+        let frontmostBundleId = try XCTUnwrap(NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+        let firstSessionId = "s-smart-question-first"
+        let secondSessionId = "s-smart-question-second"
+        var firstSession = SessionSnapshot()
+        firstSession.termApp = "Ghostty"
+        firstSession.termBundleId = frontmostBundleId
+        var secondSession = SessionSnapshot()
+        secondSession.termApp = "Ghostty"
+        secondSession.termBundleId = frontmostBundleId
+        appState.sessions[firstSessionId] = firstSession
+        appState.sessions[secondSessionId] = secondSession
+        XCTAssertFalse(appState.shouldAutoOpenPendingSurface(for: firstSessionId), "test setup must model Smart Suppress considering the first Ghostty-backed session frontmost")
+        XCTAssertFalse(appState.shouldAutoOpenPendingSurface(for: secondSessionId), "test setup must model Smart Suppress considering the second Ghostty-backed session frontmost")
+
+        let firstEvent = try makeAskUserQuestionEvent(
+            sessionId: firstSessionId,
+            questions: [
+                question(header: "第一步", text: "先处理第一个问题吗？", options: ["继续", "停止"])
+            ]
+        )
+        let secondEvent = try makeAskUserQuestionEvent(
+            sessionId: secondSessionId,
+            questions: [
+                question(header: "第二步", text: "现在处理第二个问题吗？", options: ["继续", "停止"])
+            ]
+        )
+
+        let firstResponseTask = Task<Data, Never> {
+            await withCheckedContinuation { continuation in
+                appState.handleAskUserQuestion(firstEvent, continuation: continuation)
+            }
+        }
+        await Task.yield()
+        let secondResponseTask = Task<Data, Never> {
+            await withCheckedContinuation { continuation in
+                appState.handleAskUserQuestion(secondEvent, continuation: continuation)
+            }
+        }
+        await Task.yield()
+        let queueCountAfterEnqueue = appState.questionQueue.count
+
+        appState.skipQuestion()
+        _ = await firstResponseTask.value
+        await Task.yield()
+        let queueCountAfterPromotingSecond = appState.questionQueue.count
+        let surfaceAfterPromotingSecond = appState.surface
+
+        appState.skipQuestion()
+        _ = await secondResponseTask.value
+
+        XCTAssertEqual(queueCountAfterEnqueue, 2)
+        XCTAssertEqual(queueCountAfterPromotingSecond, 1)
+        XCTAssertEqual(
+            surfaceAfterPromotingSecond,
+            .questionCard(sessionId: secondSessionId),
+            "showNextPending must open the next AskUserQuestion card even when Smart Suppress considers that Ghostty-backed terminal frontmost; otherwise queued OMP questions remain hidden behind the compact badge."
+        )
     }
 
     // MARK: - Skip returns deny


### PR DESCRIPTION
## 修改内容

- 即使「智能抑制」判断相关终端正在前台，也始终展开阻塞中的 `AskUserQuestion` 问题卡片
- 排队中的 `AskUserQuestion` 被提升为当前问题时，同样自动展开
- 普通审批和非阻塞问题仍保留原有「智能抑制」行为
- 增加 OMP 与 CodeIsland 互相等待场景的回归测试

## 根因

#244 为 OMP 增加回答回填后，OMP 扩展会先阻塞 `ask` 工具调用，等待 CodeIsland 返回答案。在这段等待期间，OMP 的终端选择框按设计还没有打开。

但 CodeIsland 的「智能抑制」仍把前台终端当作另一个可回答入口，因此将自己的问题卡片保持为收起状态。结果是：CodeIsland 没有可操作的问题卡片，OMP 终端也不会显示选择框，直到 OMP 的 extension handler 超时后才恢复。

因此，`AskUserQuestion` 不能作为「重复通知」被抑制，而应视为必须立即展示的阻塞式交互请求；其他待处理卡片继续沿用现有「智能抑制」判断。

这是 #244 的后续修复。

## 验证

- `swift test --filter AppStateQuestionFlowTests -Xswiftc -Xfrontend -Xswiftc -enable-constraint-solver-performance-hacks`
- `swift test --filter AppStatePermissionFlowTests/testSmartSuppressKeepsPendingSurfaceCollapsedWhenTerminalIsFrontmost -Xswiftc -Xfrontend -Xswiftc -enable-constraint-solver-performance-hacks`
- `swiftc -parse Sources/CodeIsland/AppState.swift`
- `swiftc -parse Tests/CodeIslandTests/AppStateQuestionFlowTests.swift`
- `git diff --check`
