### PR TITLE
fix: support Codex Desktop hosted by ChatGPT

### DIFF
--- a/Sources/CodeIsland/AppState+TranscriptTailer.swift
+++ b/Sources/CodeIsland/AppState+TranscriptTailer.swift
@@ -23,7 +23,53 @@ extension AppState {
             sessions[sessionId] = session
         }
 
+        if sessions[sessionId]?.source == "codex",
+           let turnStatus = Self.latestCodexTurnStatus(path: path),
+           var session = sessions[sessionId] {
+            switch turnStatus {
+            case .processing:
+                session.status = .processing
+                session.interrupted = false
+                session.taskRoundEnded = false
+            case .idle:
+                session.status = .idle
+                session.currentTool = nil
+                session.toolDescription = nil
+            }
+            if let modifiedAt = (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date {
+                session.lastActivity = modifiedAt
+            }
+            sessions[sessionId] = session
+        }
+
         transcriptTailer.attach(sessionId: sessionId, filePath: path)
+    }
+
+    private nonisolated static func latestCodexTurnStatus(path: String) -> ConversationTurnStatus? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { handle.closeFile() }
+
+        // A long Codex turn can place its task_started event well before the
+        // final 128 KB after emitting large reasoning/tool rows. Scan in chunks
+        // so startup state recovery remains bounded in memory without missing
+        // that event.
+        handle.seek(toFileOffset: 0)
+        let chunkSize = 64 * 1024
+        var pendingFragment = Data()
+        var latestStatus: ConversationTurnStatus?
+
+        while true {
+            let chunk = handle.readData(ofLength: chunkSize)
+            if chunk.isEmpty { break }
+
+            let result = JSONLTailer.scanLines(pendingFragment + chunk)
+            pendingFragment = result.trailingFragment
+            if let turnStatus = result.delta.turnStatus {
+                latestStatus = turnStatus
+            }
+        }
+
+        return latestStatus
     }
 
     /// Stop watching a session's transcript. Called when the session is removed or
@@ -37,6 +83,28 @@ extension AppState {
     func applyTranscriptDelta(_ delta: ConversationTailDelta) {
         guard var session = sessions[delta.sessionId] else { return }
         var mutated = false
+
+        if delta.hasActivity {
+            session.lastActivity = Date()
+            mutated = true
+        }
+
+        if let turnStatus = delta.turnStatus {
+            switch turnStatus {
+            case .processing:
+                session.status = .processing
+                session.interrupted = false
+                session.taskRoundEnded = false
+            case .idle:
+                session.status = .idle
+                session.currentTool = nil
+                session.toolDescription = nil
+            }
+            // A status-only event is still activity. This matters for a long Codex
+            // turn whose transcript has not emitted a message yet.
+            session.lastActivity = Date()
+            mutated = true
+        }
 
         if let prompt = delta.lastUserPrompt, session.lastUserPrompt != prompt {
             session.lastUserPrompt = prompt

--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -1071,6 +1071,17 @@ final class AppState {
             return
         }
 
+        let source = event.rawJSON["_source"] as? String
+        let hasTranscriptPath = (event.rawJSON["transcript_path"] as? String)
+            .map { !$0.isEmpty } ?? false
+        if Self.isCodexPlaceholderHook(
+            source: source,
+            cwd: event.rawJSON["cwd"] as? String,
+            hasTranscriptPath: hasTranscriptPath
+        ) {
+            return
+        }
+
         let sessionId = event.sessionId ?? "default"
 
         // Skip Codex APP internal sessions (title generation, etc.) — they have no transcript
@@ -2437,6 +2448,10 @@ final class AppState {
                 if backfillSessionMessages(sessionId: info.sessionId, from: info) {
                     didMutate = true
                 }
+                if sessions[info.sessionId]?.cwd != info.cwd {
+                    sessions[info.sessionId]?.cwd = info.cwd
+                    didMutate = true
+                }
                 if let path = info.transcriptPath, sessions[info.sessionId]?.transcriptPath != path {
                     sessions[info.sessionId]?.transcriptPath = path
                     didMutate = true
@@ -2488,6 +2503,10 @@ final class AppState {
                     }
                 }
                 if backfillSessionMessages(sessionId: existingKey, from: info) {
+                    didMutate = true
+                }
+                if sessions[existingKey]?.cwd != info.cwd {
+                    sessions[existingKey]?.cwd = info.cwd
                     didMutate = true
                 }
                 if let path = info.transcriptPath, sessions[existingKey]?.transcriptPath != path {
@@ -4119,6 +4138,49 @@ final class AppState {
 
     /// Find running Codex processes.
     /// Checks both executable path (Desktop app) and command-line args (npm/Homebrew: node script).
+    nonisolated static func isCodexExecutablePath(_ path: String) -> Bool {
+        let executableURL = URL(fileURLWithPath: path).standardizedFileURL
+        let lowerPath = executableURL.path.lowercased()
+        let resourceSuffix = "/contents/resources/codex"
+        guard lowerPath.hasSuffix(resourceSuffix) else { return false }
+
+        // Since Codex was folded into ChatGPT Desktop, the same com.openai.codex
+        // bundle can now be installed as ChatGPT.app instead of Codex.app. Read
+        // the bundle identifier first so future app renames continue to work.
+        let appURL = executableURL
+            .deletingLastPathComponent() // Resources
+            .deletingLastPathComponent() // Contents
+            .deletingLastPathComponent() // *.app
+        if Bundle(url: appURL)?.bundleIdentifier == AppState.codexAppBundleId {
+            return true
+        }
+
+        // Keep the legacy path check for synthetic/test bundles without an
+        // Info.plist and for older installations whose bundle cannot be read.
+        let appName = appURL.deletingPathExtension().lastPathComponent.lowercased()
+        return appName == "codex" || appName == "chatgpt"
+    }
+
+    /// Codex Desktop's shared app-server is launched with `/` as its cwd. Its
+    /// rollout metadata contains the project cwd, so desktop discovery must
+    /// use that value instead of comparing every transcript to `/`.
+    nonisolated static func codexDiscoveryUsesTranscriptCwd(processCwd: String?) -> Bool {
+        guard let processCwd, !processCwd.isEmpty else { return true }
+        return processCwd == "/"
+    }
+
+    /// Codex Desktop currently invokes some hooks without a payload, or with
+    /// the shared app-server's root cwd. Those events contain no session data
+    /// and would overwrite a session discovered from its rollout transcript.
+    nonisolated static func isCodexPlaceholderHook(
+        source: String?,
+        cwd: String?,
+        hasTranscriptPath: Bool
+    ) -> Bool {
+        guard source?.lowercased() == "codex", !hasTranscriptPath else { return false }
+        return cwd == nil || cwd?.trimmingCharacters(in: .whitespacesAndNewlines) == "/"
+    }
+
     private nonisolated static func findCodexPids(candidatePids: [pid_t]? = nil) -> [pid_t] {
         var codexPids: [pid_t] = []
 
@@ -4126,8 +4188,9 @@ final class AppState {
             guard let path = executablePath(for: pid) else { continue }
             let pathLower = path.lowercased()
 
-            // Match 1: Codex Desktop app (native binary)
-            if pathLower.contains("codex.app/contents/") && pathLower.hasSuffix("/codex") {
+            // Match 1: Codex Desktop app (native binary). The executable may
+            // live under Codex.app or ChatGPT.app depending on the release.
+            if isCodexExecutablePath(path) {
                 codexPids.append(pid)
                 continue
             }
@@ -4192,50 +4255,66 @@ final class AppState {
         var seenSessionIds: Set<String> = []
 
         for pid in codexPids {
-            guard let cwd = getCwd(for: pid), !cwd.isEmpty, !isSubagentWorktree(cwd) else {
-                // getCwd failed
+            let processCwd = getCwd(for: pid)
+            let useTranscriptCwd = codexDiscoveryUsesTranscriptCwd(processCwd: processCwd)
+            if !useTranscriptCwd,
+               let processCwd,
+               isSubagentWorktree(processCwd) {
                 continue
             }
-            // pid found
+
             let processStart = getProcessStartTime(pid)
 
-            // Codex stores sessions in date-based dirs: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
-            // Scan recent directories for matching session files
-            guard let bestFile = findRecentCodexSession(base: sessionsBase, cwd: cwd, after: processStart, fm: fm) else {
-                // no session file found
-                continue
+            // Codex stores sessions in date-based dirs: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl.
+            // A terminal process maps to one cwd; the shared Desktop app-server
+            // may own several sessions, so inspect all fresh rollouts instead.
+            let files: [String]
+            if useTranscriptCwd {
+                files = findRecentCodexSessions(base: sessionsBase, after: processStart, fm: fm)
+            } else if let processCwd,
+                      let bestFile = findRecentCodexSession(
+                        base: sessionsBase,
+                        cwd: processCwd,
+                        after: processStart,
+                        fm: fm
+                      ) {
+                files = [bestFile]
+            } else {
+                files = []
             }
 
-            // Extract session ID from filename: rollout-{date}-{uuid}.jsonl
-            let fileName = (bestFile as NSString).lastPathComponent
-            let sessionId = extractCodexSessionId(from: fileName)
-            guard !sessionId.isEmpty, !seenSessionIds.contains(sessionId) else { continue }
-            seenSessionIds.insert(sessionId)
+            for file in files {
+                let fileName = (file as NSString).lastPathComponent
+                let sessionId = extractCodexSessionId(from: fileName)
+                guard !sessionId.isEmpty, !seenSessionIds.contains(sessionId) else { continue }
+                seenSessionIds.insert(sessionId)
 
-            let modifiedAt = (try? fm.attributesOfItem(atPath: bestFile))?[.modificationDate] as? Date ?? Date()
+                let modifiedAt = (try? fm.attributesOfItem(atPath: file))?[.modificationDate] as? Date ?? Date()
+                let codexFreshnessLimit: TimeInterval = processStart != nil ? -300 : -30
+                if modifiedAt.timeIntervalSinceNow < codexFreshnessLimit { continue }
 
-            // Skip stale transcripts: tighter window when processStart is unknown
-            let codexFreshnessLimit: TimeInterval = processStart != nil ? -300 : -30
-            if modifiedAt.timeIntervalSinceNow < codexFreshnessLimit { continue }
+                let sessionCwd = codexSessionCwd(path: file) ?? processCwd
+                guard let sessionCwd, !sessionCwd.isEmpty, !isSubagentWorktree(sessionCwd) else { continue }
 
-            let (model, messages) = readRecentFromCodexTranscript(path: bestFile)
-            let subagentMetadata = codexSubagentMetadata(inTranscriptPath: bestFile)
+                let (model, messages) = readRecentFromCodexTranscript(path: file)
+                let subagentMetadata = codexSubagentMetadata(inTranscriptPath: file)
 
-            results.append(DiscoveredSession(
-                sessionId: sessionId,
-                cwd: cwd,
-                tty: nil,
-                model: model,
-                pid: pid,
-                modifiedAt: modifiedAt,
-                recentMessages: messages,
-                source: "codex",
-                transcriptPath: bestFile,
-                parentSessionId: subagentMetadata?.parentThreadId,
-                subagentStatus: codexThreadSpawnStatus(childThreadId: sessionId),
-                agentType: subagentMetadata?.agentType,
-                agentNickname: subagentMetadata?.agentNickname
-            ))
+                results.append(DiscoveredSession(
+                    sessionId: sessionId,
+                    cwd: sessionCwd,
+                    tty: nil,
+                    model: model,
+                    pid: pid,
+                    modifiedAt: modifiedAt,
+                    recentMessages: messages,
+                    source: "codex",
+                    transcriptPath: file,
+                    parentSessionId: subagentMetadata?.parentThreadId,
+                    subagentStatus: codexThreadSpawnStatus(childThreadId: sessionId),
+                    agentType: subagentMetadata?.agentType,
+                    agentNickname: subagentMetadata?.agentNickname
+                ))
+            }
         }
         return results
     }
@@ -4375,6 +4454,11 @@ final class AppState {
     /// Find the most recent Codex session file matching a CWD
     /// Scans back up to 7 days to cover long-running sessions that span day boundaries
     private nonisolated static func findRecentCodexSession(base: String, cwd: String, after: Date?, fm: FileManager) -> String? {
+        findRecentCodexSessions(base: base, after: after, fm: fm)
+            .first(where: { codexSessionMatchesCwd(path: $0, cwd: cwd) })
+    }
+
+    private nonisolated static func findRecentCodexSessions(base: String, after: Date?, fm: FileManager) -> [String] {
         let cal = Calendar.current
         let now = Date()
         var dirs: [String] = []
@@ -4388,11 +4472,12 @@ final class AppState {
                 dirs.append(dir)
             }
         }
-        guard !dirs.isEmpty else { return nil }
-        return scanCodexDir(dirs: dirs, cwd: cwd, after: after, fm: fm)
+        guard !dirs.isEmpty else { return [] }
+        return scanCodexDir(dirs: dirs, after: after, fm: fm)
     }
 
-    private nonisolated static func scanCodexDir(dirs: [String], cwd: String, after: Date?, fm: FileManager) -> String? {
+    private nonisolated static func scanCodexDir(dirs: [String], after: Date?, fm: FileManager) -> [String] {
+        var results: [String] = []
         for dir in dirs {
             guard let files = try? fm.contentsOfDirectory(atPath: dir) else { continue }
             // Sort descending to check newest first
@@ -4406,26 +4491,24 @@ final class AppState {
                    modified < start.addingTimeInterval(-10) {
                     continue
                 }
-                if codexSessionMatchesCwd(path: fullPath, cwd: cwd) {
-                    return fullPath
-                }
+                results.append(fullPath)
             }
         }
-        return nil
+        return results
     }
 
     /// Check if a Codex session file's CWD matches the target
     private nonisolated static func codexSessionMatchesCwd(path: String, cwd: String) -> Bool {
-        guard let handle = FileHandle(forReadingAtPath: path) else { return false }
-        defer { handle.closeFile() }
-        let data = handle.readData(ofLength: 4096) // First line is enough
-        guard let text = String(data: data, encoding: .utf8),
-              let firstLine = text.components(separatedBy: "\n").first,
+        codexSessionCwd(path: path) == cwd
+    }
+
+    nonisolated static func codexSessionCwd(path: String) -> String? {
+        guard let firstLine = readFirstLine(path: path),
               let lineData = firstLine.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
               let payload = json["payload"] as? [String: Any],
-              let sessionCwd = payload["cwd"] as? String else { return false }
-        return sessionCwd == cwd
+              let sessionCwd = payload["cwd"] as? String else { return nil }
+        return sessionCwd
     }
 
     /// Extract session ID from Codex filename: rollout-2026-04-04T20-54-48-{uuid}.jsonl

--- a/Sources/CodeIslandCore/JSONLTailer.swift
+++ b/Sources/CodeIslandCore/JSONLTailer.swift
@@ -1,21 +1,36 @@
 import Foundation
 import Darwin
 
+public enum ConversationTurnStatus: Equatable, Sendable {
+    case processing
+    case idle
+}
+
 /// A delta emitted by `JSONLTailer` whenever the watched transcript grows.
 public struct ConversationTailDelta: Equatable, Sendable {
     public let sessionId: String
     public let lastUserPrompt: String?
     public let lastAssistantMessage: String?
+    public let turnStatus: ConversationTurnStatus?
+    public let hasActivity: Bool
 
-    public init(sessionId: String, lastUserPrompt: String?, lastAssistantMessage: String?) {
+    public init(
+        sessionId: String,
+        lastUserPrompt: String?,
+        lastAssistantMessage: String?,
+        turnStatus: ConversationTurnStatus? = nil,
+        hasActivity: Bool = false
+    ) {
         self.sessionId = sessionId
         self.lastUserPrompt = lastUserPrompt
         self.lastAssistantMessage = lastAssistantMessage
+        self.turnStatus = turnStatus
+        self.hasActivity = hasActivity
     }
 
     /// A delta only carries signal when at least one field is non-nil.
     public var isEmpty: Bool {
-        lastUserPrompt == nil && lastAssistantMessage == nil
+        lastUserPrompt == nil && lastAssistantMessage == nil && turnStatus == nil && !hasActivity
     }
 }
 
@@ -187,7 +202,9 @@ public final class JSONLTailer: @unchecked Sendable {
             let delta = ConversationTailDelta(
                 sessionId: watch.sessionId,
                 lastUserPrompt: scan.delta.lastUserPrompt,
-                lastAssistantMessage: scan.delta.lastAssistantMessage
+                lastAssistantMessage: scan.delta.lastAssistantMessage,
+                turnStatus: scan.delta.turnStatus,
+                hasActivity: scan.delta.hasActivity
             )
             onDelta(delta)
         }
@@ -220,7 +237,11 @@ public final class JSONLTailer: @unchecked Sendable {
         public struct Delta: Equatable {
             public var lastUserPrompt: String?
             public var lastAssistantMessage: String?
-            public var isEmpty: Bool { lastUserPrompt == nil && lastAssistantMessage == nil }
+            public var turnStatus: ConversationTurnStatus?
+            public var hasActivity = false
+            public var isEmpty: Bool {
+                lastUserPrompt == nil && lastAssistantMessage == nil && turnStatus == nil && !hasActivity
+            }
         }
         public let delta: Delta
         public let trailingFragment: Data
@@ -248,6 +269,11 @@ public final class JSONLTailer: @unchecked Sendable {
 
         let fragment = Data(data[lineStart..<data.endIndex])
         return ScanResult(delta: delta, trailingFragment: fragment)
+    }
+
+    /// Return the most recent Codex turn state in a transcript blob.
+    public static func latestTurnStatus(in data: Data) -> ConversationTurnStatus? {
+        scanLines(data).delta.turnStatus
     }
 
     private static func apply(line: Data.SubSequence, into delta: inout ScanResult.Delta) {
@@ -285,6 +311,18 @@ public final class JSONLTailer: @unchecked Sendable {
                     delta.lastAssistantMessage = trimmed
                 }
             }
+        case "event_msg":
+            delta.hasActivity = true
+            guard let payload = json["payload"] as? [String: Any],
+                  let eventType = payload["type"] as? String else { return }
+            switch eventType {
+            case "task_started":
+                delta.turnStatus = .processing
+            case "task_complete", "turn_aborted", "turn_failed":
+                delta.turnStatus = .idle
+            default:
+                break
+            }
         default:
             break
         }
@@ -296,6 +334,7 @@ public final class JSONLTailer: @unchecked Sendable {
     enum QuickTypeKind: Equatable {
         case user
         case assistant
+        case codexEvent
         case irrelevant
     }
 
@@ -348,6 +387,10 @@ public final class JSONLTailer: @unchecked Sendable {
                             if hasExactValue(ptr, at: valueStart, total: total, expect: plannerResponseBytes) {
                                 return .assistant
                             }
+                        case 0x65:  // 'e'
+                            if hasExactValue(ptr, at: valueStart, total: total, expect: eventMsgBytes) {
+                                return .codexEvent
+                            }
                         default:
                             break
                         }
@@ -370,6 +413,8 @@ public final class JSONLTailer: @unchecked Sendable {
     private static let assistantBytes: [UInt8] = Array(#"assistant""#.utf8)
     private static let userInputBytes: [UInt8] = Array(#"USER_INPUT""#.utf8)
     private static let plannerResponseBytes: [UInt8] = Array(#"PLANNER_RESPONSE""#.utf8)
+
+    private static let eventMsgBytes: [UInt8] = Array(#"event_msg""#.utf8)
 
     private static func hasExactValue(
         _ ptr: UnsafePointer<UInt8>,

--- a/Tests/CodeIslandCoreTests/JSONLTailerTests.swift
+++ b/Tests/CodeIslandCoreTests/JSONLTailerTests.swift
@@ -104,6 +104,43 @@ final class JSONLTailerTests: XCTestCase {
         XCTAssertNil(result.delta.lastUserPrompt)
     }
 
+    func testScanLinesExtractsCodexTaskStartedAsProcessing() {
+        let line = #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#
+        let result = JSONLTailer.scanLines(Data((line + "\n").utf8))
+
+        XCTAssertEqual(result.delta.turnStatus, .processing)
+        XCTAssertFalse(result.delta.isEmpty)
+    }
+
+    func testScanLinesExtractsCodexTerminalTurnEventsAsIdle() {
+        let lines = [
+            #"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted"}}"#,
+            #"{"type":"event_msg","payload":{"type":"turn_failed","reason":"tool_error"}}"#
+        ].joined(separator: "\n")
+        let result = JSONLTailer.scanLines(Data((lines + "\n").utf8))
+
+        XCTAssertEqual(result.delta.turnStatus, .idle)
+        XCTAssertFalse(result.delta.isEmpty)
+    }
+
+    func testLatestTurnStatusUsesMostRecentCodexTurnEvent() {
+        let lines = [
+            #"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"}}"#
+        ].joined(separator: "\n")
+
+        XCTAssertEqual(JSONLTailer.latestTurnStatus(in: Data((lines + "\n").utf8)), .processing)
+    }
+
+    func testScanLinesTreatsCodexEventMessagesAsActivity() {
+        let line = #"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{}}}}"#
+        let result = JSONLTailer.scanLines(Data((line + "\n").utf8))
+
+        XCTAssertTrue(result.delta.hasActivity)
+        XCTAssertFalse(result.delta.isEmpty)
+    }
+
     // MARK: - extractText
 
     func testExtractTextFromPlainString() {

--- a/Tests/CodeIslandTests/AppStateCodexAppServerTests.swift
+++ b/Tests/CodeIslandTests/AppStateCodexAppServerTests.swift
@@ -4,6 +4,69 @@ import XCTest
 
 @MainActor
 final class AppStateCodexAppServerTests: XCTestCase {
+    func testCodexExecutablePathRecognizesChatGPTDesktopBundle() {
+        XCTAssertTrue(AppState.isCodexExecutablePath(
+            "/Applications/ChatGPT.app/Contents/Resources/codex"
+        ))
+    }
+
+    func testCodexExecutablePathRejectsUnrelatedResourceBinary() {
+        XCTAssertFalse(AppState.isCodexExecutablePath(
+            "/Applications/OtherAgent.app/Contents/Resources/codex"
+        ))
+    }
+
+    func testCodexDiscoveryUsesTranscriptCwdForDesktopProcess() {
+        XCTAssertTrue(AppState.codexDiscoveryUsesTranscriptCwd(processCwd: nil))
+        XCTAssertTrue(AppState.codexDiscoveryUsesTranscriptCwd(processCwd: "/"))
+        XCTAssertFalse(AppState.codexDiscoveryUsesTranscriptCwd(
+            processCwd: "/Users/haoo/Documents/project"
+        ))
+    }
+
+    func testCodexPlaceholderHookIsIgnoredButProjectHookIsKept() {
+        XCTAssertTrue(AppState.isCodexPlaceholderHook(
+            source: "codex",
+            cwd: "/",
+            hasTranscriptPath: false
+        ))
+        XCTAssertTrue(AppState.isCodexPlaceholderHook(
+            source: "codex",
+            cwd: nil,
+            hasTranscriptPath: false
+        ))
+        XCTAssertFalse(AppState.isCodexPlaceholderHook(
+            source: "codex",
+            cwd: "/Users/haoo/Documents/project",
+            hasTranscriptPath: false
+        ))
+        XCTAssertFalse(AppState.isCodexPlaceholderHook(
+            source: "codex",
+            cwd: "/",
+            hasTranscriptPath: true
+        ))
+    }
+
+    func testCodexTranscriptCwdReadsLargeSessionMetaLine() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codeisland-codex-meta-(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let payload: [String: Any] = [
+            "cwd": "/Users/haoo/Documents/project",
+            "instructions": String(repeating: "x", count: 10_000),
+        ]
+        let object: [String: Any] = ["type": "session_meta", "payload": payload]
+        var data = try JSONSerialization.data(withJSONObject: object)
+        data.append(0x0A)
+        try data.write(to: url)
+
+        XCTAssertEqual(
+            AppState.codexSessionCwd(path: url.path),
+            "/Users/haoo/Documents/project"
+        )
+    }
+
     func testCodexAppServerExecutablePrefersRunningBundlePath() throws {
         let fm = FileManager.default
         let tempDir = fm.temporaryDirectory.appendingPathComponent("codeisland-codex-app-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary

- Recognize Codex Desktop when its executable is hosted by ChatGPT.app.
- Discover project cwd and session metadata from Codex rollout transcripts when the shared app-server cwd is `/`.
- Ignore empty/root-cwd placeholder hooks that would overwrite a real discovered session.
- Parse Codex JSONL `task_started`, `task_complete`, `turn_aborted`, and `turn_failed` events into CodeIsland running/idle state.
- Treat Codex event messages as activity heartbeats so long turns are not reset to idle by the timeout watchdog.

## Background

Codex has recently been integrated into ChatGPT as a multi-purpose host application. On macOS, the Codex executable can now run from:

`/Applications/ChatGPT.app/Contents/Resources/codex`

The shared app-server commonly reports `/` as its cwd, while the actual project cwd is stored in the rollout transcript metadata. Some desktop invocations also emit empty or root-cwd hook payloads.

The previous CodeIsland integration assumed the older standalone Codex.app layout and relied on hook/message parsing for live status, so sessions could be discovered but remained idle.

## Test Plan

- `swift build -c release --arch arm64` passes.
- Added JSONL parser coverage for Codex turn lifecycle events, latest turn recovery, and activity heartbeats.
- Added discovery coverage for ChatGPT.app executable paths, large session metadata, transcript cwd recovery, and placeholder hooks.
- `swift test` could not run on the development machine because the active Command Line Tools installation has no XCTest module; the test targets report this environment error. CI with a full Xcode toolchain should run the test suite.
