### PR TITLE
fix(codex): cap SessionEnd hook timeout at 3s

### DIFF
--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -227,7 +227,7 @@ struct ConfigInstaller {
             format: .nested,
             events: [
                 ("SessionStart", 5, false),
-                ("SessionEnd", 5, true),
+                ("SessionEnd", 3, true),
                 ("UserPromptSubmit", 5, false),
                 ("PreToolUse", 5, false),
                 ("PostToolUse", 5, false),

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -124,6 +124,48 @@ final class ConfigInstallerTests: XCTestCase {
         XCTAssertTrue(command.contains("--event stop"))
     }
 
+    func testCodexSessionEndTimeoutRespectsTeardownCapAndRepairsStaleConfig() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        let staleConfig = """
+        {
+          "hooks": {
+            "SessionEnd": [
+              {
+                "hooks": [
+                  {
+                    "type": "command",
+                    "command": "/Users/test/.codeisland/codeisland-bridge --source codex",
+                    "timeout": 5
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """
+        let configPath = tempDir.appendingPathComponent("hooks.json")
+        try staleConfig.write(to: configPath, atomically: true, encoding: .utf8)
+
+        var codex = try XCTUnwrap(ConfigInstaller.allCLIs.first { $0.source == "codex" })
+        let tempPath = tempDir.path
+        codex.rootOverride = { tempPath }
+
+        let configuredTimeout = try XCTUnwrap(codex.events.first { $0.0 == "SessionEnd" }?.1)
+        XCTAssertEqual(configuredTimeout, 3)
+        XCTAssertTrue(ConfigInstaller.installExternalHooks(cli: codex, fm: fm))
+
+        let data = try Data(contentsOf: configPath)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try XCTUnwrap(root["hooks"] as? [String: Any])
+        let sessionEnd = try XCTUnwrap(hooks["SessionEnd"] as? [[String: Any]])
+        let hookList = try XCTUnwrap(sessionEnd.first?["hooks"] as? [[String: Any]])
+        XCTAssertEqual(hookList.first?["timeout"] as? Int, 3)
+    }
+
     func testTraeIDEHooksUseOfficialNestedSchema() throws {
         let fm = FileManager.default
         let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary

- Set the Codex `SessionEnd` hook timeout from 5s to 3s.
- Add regression coverage for rewriting stale CodeIsland-managed config.

Codex caps `SessionEnd` teardown hooks at 3 seconds; larger values trigger the startup warning.

Upstream reference: https://github.com/openai/codex/pull/33895

## Test

- `swift build --disable-sandbox -c release --target CodeIsland`
