### PR TITLE
fix: harden closed-subagent tombstones and kimi hooks status

### DIFF
--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -2345,7 +2345,7 @@ final class AppState {
             snapshot.lastActivity = p.lastActivity
             snapshot.transcriptPath = p.transcriptPath
             if let closed = p.closedSubagentIds, !closed.isEmpty {
-                snapshot.closedSubagentIds = Set(closed)
+                snapshot.restoreClosedSubagentIds(closed)
             }
             // Restore persisted cliPid only if the process is still alive — avoids
             // stale sessions reappearing briefly after the app or IDE restarts (#46).
@@ -2395,7 +2395,7 @@ final class AppState {
         sessionId: String,
         providerSessionId: String?,
         transcriptPath: String?,
-        closedSubagentIds: Set<String>
+        closedSubagentIds: [String]
     ) -> Bool {
         guard source == "cursor" || source == "cursor-cli" else { return false }
         return !closedSubagentIds.isEmpty
@@ -2839,10 +2839,9 @@ final class AppState {
             // Closed ids may sit on the parent (merge Stop) or the child card
             // (separate Stop). Parent tombstone always wins over a late-running
             // orphan card — relaunch clears via UserPromptSubmit on the hook path.
-            let childClosed = candidate.session.closedSubagentIds
-            let candidateCarriesClosed = childClosed.contains(childId)
-                || childClosed.contains(candidate.sessionId)
-            let parentHoldsTombstone = sessions[parentKey]?.closedSubagentIds.contains(childId) == true
+            let candidateCarriesClosed = candidate.session.hasClosedSubagentId(childId)
+                || candidate.session.hasClosedSubagentId(candidate.sessionId)
+            let parentHoldsTombstone = sessions[parentKey]?.hasClosedSubagentId(childId) == true
 
             if candidateCarriesClosed || parentHoldsTombstone {
                 if sessions[parentKey] == nil {
@@ -2863,7 +2862,7 @@ final class AppState {
                     onto: parentKey,
                     childId: childId,
                     candidateSessionId: candidate.sessionId,
-                    childClosed: childClosed
+                    childClosed: candidate.session.closedSubagentIds
                 )
                 if sessions[candidate.sessionId] != nil {
                     removeSession(candidate.sessionId)
@@ -2950,14 +2949,14 @@ final class AppState {
         onto parentKey: String,
         childId: String,
         candidateSessionId: String,
-        childClosed: Set<String>
+        childClosed: [String]
     ) {
-        sessions[parentKey]?.closedSubagentIds.insert(childId)
+        sessions[parentKey]?.recordClosedSubagentId(childId)
         if candidateSessionId != childId {
-            sessions[parentKey]?.closedSubagentIds.insert(candidateSessionId)
+            sessions[parentKey]?.recordClosedSubagentId(candidateSessionId)
         }
         for id in childClosed where id == childId || id == candidateSessionId {
-            sessions[parentKey]?.closedSubagentIds.insert(id)
+            sessions[parentKey]?.recordClosedSubagentId(id)
         }
     }
 
@@ -3028,11 +3027,10 @@ final class AppState {
     }
 
     /// Suppress Permission/Question UI for Stop'd Tasks: merged `agent_id` tombstones
-    /// or separate-mode self-tombstones (`closedSubagentIds` contains the card id).
+    /// or separate-mode self-tombstones (card id recorded in ``closedSubagentIds``).
     private func shouldSuppressClosedSubagentUI(sessionId: String, agentId: String?) -> Bool {
-        let closed = sessions[sessionId]?.closedSubagentIds ?? []
-        if let agentId, closed.contains(agentId) { return true }
-        if agentId == nil, closed.contains(sessionId) { return true }
+        if let agentId, sessions[sessionId]?.hasClosedSubagentId(agentId) == true { return true }
+        if agentId == nil, sessions[sessionId]?.hasClosedSubagentId(sessionId) == true { return true }
         return false
     }
 
@@ -3321,6 +3319,8 @@ final class AppState {
 
     func stopSessionDiscovery() {
         tearDownProjectsWatcher()
+        rotationTimer?.invalidate()
+        rotationTimer = nil
         cleanupTimer?.invalidate()
         cleanupTimer = nil
         saveTimer?.invalidate()
@@ -3334,42 +3334,61 @@ final class AppState {
     /// Stops the FSEvents watcher on the main queue so Stop/Invalidate cannot
     /// race a queued callback. Safe to call from `deinit` (any thread).
     nonisolated private func tearDownProjectsWatcher() {
-        let teardown = { [self] in
-            // Flip cancel before stopping so any already-queued callback no-ops
-            // instead of touching a dying AppState / freed box.
-            projectsWatcherBox?.cancel()
-            if let stream = fsEventStream {
-                FSEventStreamStop(stream)
-                FSEventStreamInvalidate(stream)
-                FSEventStreamRelease(stream)
-                fsEventStream = nil
-            }
-            let box = projectsWatcherBox
-            projectsWatcherBox = nil
-            // Keep the box alive until after previously queued main-queue
-            // callbacks drain (Invalidate does not flush them).
-            if let box {
-                DispatchQueue.main.async { _ = box }
-            }
-        }
+        let run = { [self] in tearDownProjectsWatcherAssumingMain() }
         if Thread.isMainThread {
-            teardown()
+            run()
         } else {
-            DispatchQueue.main.sync(execute: teardown)
+            DispatchQueue.main.sync(execute: run)
+        }
+    }
+
+    /// FSEvents teardown; caller must already be on the main queue.
+    nonisolated private func tearDownProjectsWatcherAssumingMain() {
+        // Flip cancel before stopping so any already-queued callback no-ops
+        // instead of touching a dying AppState / freed box.
+        projectsWatcherBox?.cancel()
+        if let stream = fsEventStream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            fsEventStream = nil
+        }
+        let box = projectsWatcherBox
+        projectsWatcherBox = nil
+        // Keep the box alive until after previously queued main-queue
+        // callbacks drain (Invalidate does not flush them).
+        if let box {
+            DispatchQueue.main.async { _ = box }
         }
     }
 
     deinit {
         // Must not use MainActor.assumeIsolated: async callers (notably XCTest)
         // can release AppState off the main actor via ARC. Weak-boxed FSEvents
-        // + main-synced stream teardown keep discovery teardown crash-free.
-        rotationTimer?.invalidate()
-        cleanupTimer?.invalidate()
-        saveTimer?.invalidate()
-        tearDownProjectsWatcher()
+        // + main-synced Timer/FSEvents teardown keep discovery crash-free.
+        tearDownMainThreadResources()
         discoveryScanTask?.cancel()
         for (_, monitor) in processMonitors {
             monitor.source.cancel()
+        }
+    }
+
+    /// Invalidates main-run-loop Timers and the FSEvents watcher in one main-queue
+    /// hop. Safe from any thread so `deinit` stays uniformly main-safe.
+    nonisolated private func tearDownMainThreadResources() {
+        let teardown = { [self] in
+            rotationTimer?.invalidate()
+            rotationTimer = nil
+            cleanupTimer?.invalidate()
+            cleanupTimer = nil
+            saveTimer?.invalidate()
+            saveTimer = nil
+            tearDownProjectsWatcherAssumingMain()
+        }
+        if Thread.isMainThread {
+            teardown()
+        } else {
+            DispatchQueue.main.sync(execute: teardown)
         }
     }
 
@@ -3920,6 +3939,7 @@ final class AppState {
 
     /// kimi-code tracks sessions in `~/.kimi-code/session_index.jsonl` with
     /// `{ sessionId, sessionDir, workDir }` — workdir folders are no longer md5(cwd).
+    /// `home` is the user home directory (fixture-injectable for tests).
     private nonisolated static func discoverKimiCodeSessionFromIndex(
         home: String,
         cwd: String,
@@ -3979,6 +3999,31 @@ final class AppState {
         )
     }
 
+    /// Test seam for ``discoverKimiCodeSessionFromIndex`` without exposing
+    /// private ``DiscoveredSession``.
+    internal nonisolated static func discoverKimiCodeSessionFromIndexForTesting(
+        home: String,
+        cwd: String,
+        pid: pid_t,
+        processStart: Date?,
+        fm: FileManager
+    ) -> (sessionId: String, cwd: String, pid: pid_t?, source: String, messageTexts: [String])? {
+        guard let match = discoverKimiCodeSessionFromIndex(
+            home: home,
+            cwd: cwd,
+            pid: pid,
+            processStart: processStart,
+            fm: fm
+        ) else { return nil }
+        return (
+            match.sessionId,
+            match.cwd,
+            match.pid,
+            match.source,
+            match.recentMessages.map(\.text)
+        )
+    }
+
     /// Parse recent chat turns from a Kimi wire.jsonl transcript.
     /// Supports legacy kimi-cli (`message.type = TurnBegin|ContentPart|TurnEnd`)
     /// and kimi-code (`turn.prompt` / `context.append_message` / `content.part`).
@@ -3995,6 +4040,10 @@ final class AppState {
         var messages: [ChatMessage] = []
         var previousUserText: String?
         var previousAssistantText: String = ""
+        /// True when the current open turn was started by `context.append_message`
+        /// rather than `turn.prompt` — used so a later `turn.prompt` can replace
+        /// the user text without flushing a duplicate line.
+        var turnOpenedByAppend = false
 
         func flushTurn() {
             if let userText = previousUserText, !userText.isEmpty {
@@ -4005,6 +4054,7 @@ final class AppState {
             }
             previousUserText = nil
             previousAssistantText = ""
+            turnOpenedByAppend = false
         }
 
         func textParts(from value: Any?) -> String {
@@ -4051,10 +4101,25 @@ final class AppState {
             }
 
             // kimi-code wire protocol (v1.4+).
+            // Observed order: turn.prompt opens a turn, then optional
+            // context.append_message (same user text), then content.part replies.
+            // Prefer turn.prompt when both exist. If append_message arrives first
+            // (defensive), mark the turn so the later turn.prompt replaces the
+            // user text instead of flushing a duplicate user line.
             switch json["type"] as? String {
             case "turn.prompt":
-                flushTurn()
-                previousUserText = textParts(from: json["input"])
+                let promptText = textParts(from: json["input"])
+                if turnOpenedByAppend && previousAssistantText.isEmpty {
+                    // Replace append-opened user text only when turn.prompt has
+                    // content; an empty prompt must not wipe the append line.
+                    if !promptText.isEmpty {
+                        previousUserText = promptText
+                    }
+                } else {
+                    flushTurn()
+                    previousUserText = promptText
+                }
+                turnOpenedByAppend = false
             case "context.append_message":
                 if let message = json["message"] as? [String: Any],
                    message["role"] as? String == "user" {
@@ -4064,6 +4129,7 @@ final class AppState {
                         // only start a turn here if we don't already have one open.
                         if previousUserText == nil {
                             previousUserText = userText
+                            turnOpenedByAppend = true
                         }
                     }
                 }

--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -2503,13 +2503,19 @@ struct ConfigInstaller {
         return result.joined(separator: "\n")
     }
 
+    /// Paths checked for Kimi hooks *status* (Settings installed badge).
+    /// Exactly one path: the install target (`cli.fullPath` / `kimiHome()`).
+    /// Must never OR modern + legacy — that false-positives migrated users.
+    internal static func kimiHooksStatusConfigPaths(for cli: CLIConfig) -> [String] {
+        [cli.fullPath]
+    }
+
+    /// Whether CodeIsland hooks are present in the config kimi-code (or legacy
+    /// kimi-cli) will actually read. Matches install's `cli.fullPath` target —
+    /// do not OR legacy when `~/.kimi-code` exists, or migrated users with hooks
+    /// only under `~/.kimi` show a false "installed" while kimi-code ignores them.
     private static func isKimiHooksInstalled(cli: CLIConfig, fm: FileManager) -> Bool {
-        // Prefer modern home, but also treat legacy ~/.kimi as installed if our
-        // hooks are still there (migration leaves the old tree intact).
-        var candidates = [kimiCodeHome() + "/config.toml", kimiLegacyHome() + "/config.toml"]
-        let resolved = cli.fullPath
-        if !candidates.contains(resolved) { candidates.append(resolved) }
-        return candidates.contains { path in
+        kimiHooksStatusConfigPaths(for: cli).contains { path in
             guard fm.fileExists(atPath: path),
                   let data = fm.contents(atPath: path),
                   let contents = String(data: data, encoding: .utf8) else { return false }
@@ -2517,6 +2523,19 @@ struct ConfigInstaller {
                 contentsContainsKimiHook(contents, event: event)
             }
         }
+    }
+
+    /// Test seam: status for an explicit config path (hermetic fixtures).
+    internal static func isKimiHooksInstalled(at configPath: String, cli: CLIConfig, fm: FileManager) -> Bool {
+        let probe = CLIConfig(
+            name: cli.name,
+            source: cli.source,
+            configPath: configPath,
+            configKey: cli.configKey,
+            format: cli.format,
+            events: cli.events
+        )
+        return isKimiHooksInstalled(cli: probe, fm: fm)
     }
 
     static func contentsContainsKimiHook(_ contents: String, event: String) -> Bool {

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -313,7 +313,47 @@ class HookServer {
     private static let sourceMarkerBytes = Data(#""_source""#.utf8)
     private static let codexMarkerBytes = Data("codex".utf8)
     private static let cursorTranscriptMarkerBytes = Data("agent-transcripts".utf8)
-    private static let cursorSourceMarkerBytes = Data("cursor".utf8)
+    private static let cursorSourceExactBytes = Data(#""_source":"cursor""#.utf8)
+    private static let cursorCliSourceExactBytes = Data(#""_source":"cursor-cli""#.utf8)
+    /// JSON `\uXXXX` escape — only then do we fall back to a full parse.
+    private static let jsonUnicodeEscapeBytes = Data(#"\u"#.utf8)
+    private static let cursorSourceFlexibleRegex: NSRegularExpression = {
+        try! NSRegularExpression(
+            pattern: #""_source"\s*:\s*"(cursor-cli|cursor)""#,
+            options: []
+        )
+    }()
+
+    /// Whether Cursor Task routing may need a JSON parse.
+    ///
+    /// Requires `agent-transcripts` plus `_source` of `cursor` / `cursor-cli`
+    /// (not bare "cursor" elsewhere). Fast path: compact bridge literals, then
+    /// whitespace-tolerant regex (only if `"_source"` is present). JSON fallback
+    /// runs only when a `\u` escape is also present — so non-cursor hooks whose
+    /// text merely mentions `agent-transcripts` do not pay for a parse.
+    internal static func mayNeedCursorSubsessionRouting(data: Data) -> Bool {
+        guard data.range(of: cursorTranscriptMarkerBytes) != nil else { return false }
+        // Compact forms first — bridge JSONSerialization emits no spaces after `:`.
+        if data.range(of: cursorCliSourceExactBytes) != nil
+            || data.range(of: cursorSourceExactBytes) != nil {
+            return true
+        }
+        // No `_source` key → cannot be a Cursor hook source field.
+        guard data.range(of: sourceMarkerBytes) != nil else { return false }
+        if let text = String(data: data, encoding: .utf8) {
+            let range = NSRange(text.startIndex..., in: text)
+            if cursorSourceFlexibleRegex.firstMatch(in: text, options: [], range: range) != nil {
+                return true
+            }
+        }
+        // Literal/regex miss with unicode escapes in the payload (e.g. `\u0063ursor`).
+        guard data.range(of: jsonUnicodeEscapeBytes) != nil,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let source = obj["_source"] as? String else {
+            return false
+        }
+        return source == "cursor" || source == "cursor-cli"
+    }
 
     private static func codexSubagentMetadata(from raw: [String: Any]) -> CodexSubagentMetadata? {
         guard let path = nonEmptyString(raw["transcript_path"]) else { return nil }
@@ -350,8 +390,7 @@ class HookServer {
     private func routeSubsessionPayloadIfNeeded(data: Data) -> (processedData: Data, responseData: Data?) {
         let mayNeedPluginOrCodex = data.range(of: Self.pluginMarkerBytes) != nil
             || (data.range(of: Self.sourceMarkerBytes) != nil && data.range(of: Self.codexMarkerBytes) != nil)
-        let mayNeedCursor = data.range(of: Self.cursorTranscriptMarkerBytes) != nil
-            && data.range(of: Self.cursorSourceMarkerBytes) != nil
+        let mayNeedCursor = Self.mayNeedCursorSubsessionRouting(data: data)
 
         let mode = UserDefaults.standard.string(forKey: SettingsKey.pluginSessionMode)
             ?? SettingsDefaults.pluginSessionMode

--- a/Sources/CodeIsland/SessionPersistence.swift
+++ b/Sources/CodeIsland/SessionPersistence.swift
@@ -33,7 +33,9 @@ struct PersistedSession: Codable {
     let lastActivity: Date
     /// Absolute JSONL path for session fold and transcript tailing.
     let transcriptPath: String?
-    /// Closed subagent ids; kept across relaunch so merge cannot revive them.
+    /// Closed subagent ids in insertion order (newest last). Legacy files may
+    /// still hold a lexicographically sorted list from the pre-cap `Set.sorted()`
+    /// encoder — restore keeps all entries (no fake-recency trim).
     let closedSubagentIds: [String]?
 }
 
@@ -72,7 +74,7 @@ enum SessionPersistence {
                 startTime: s.startTime,
                 lastActivity: s.lastActivity,
                 transcriptPath: s.transcriptPath,
-                closedSubagentIds: s.closedSubagentIds.isEmpty ? nil : Array(s.closedSubagentIds).sorted()
+                closedSubagentIds: s.closedSubagentIds.isEmpty ? nil : s.closedSubagentIds
             )
         }
         do {

--- a/Sources/CodeIslandCore/CursorSessionFolding.swift
+++ b/Sources/CodeIslandCore/CursorSessionFolding.swift
@@ -97,13 +97,6 @@ public enum CursorSubsessionRouter {
             raw["agent_type"] = "cursor-subagent"
         }
         raw["_cursor_subagent"] = true
-        raw["_cursor_subagent_session_id"] = childSessionId
-        if let eventName = nonEmptyString(raw["hook_event_name"])
-            ?? nonEmptyString(raw["hookEventName"])
-            ?? nonEmptyString(raw["event_name"])
-            ?? nonEmptyString(raw["eventName"]) {
-            raw["_cursor_subagent_event"] = EventNormalizer.normalize(eventName)
-        }
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -84,9 +84,18 @@ public struct SessionSnapshot: Sendable {
     public var toolHistory: [ToolHistoryEntry] = []
     public var totalToolCallCount: Int = 0
     public var subagents: [String: SubagentState] = [:]
-    /// Agent ids closed by SubagentStop/Stop/SessionEnd.
-    /// Blocks merge/fold from putting a finished subagent back on the parent.
-    public var closedSubagentIds: Set<String> = []
+    /// Agent ids closed by SubagentStop/Stop/SessionEnd, in insertion order
+    /// (newest last). Blocks merge/fold from putting a finished subagent back
+    /// on the parent. Live growth is capped at ``maxClosedSubagentIds``;
+    /// restored lists may be larger (see ``restoreClosedSubagentIds``).
+    /// Mutate only via ``recordClosedSubagentId``, ``clearClosedSubagentId``,
+    /// or ``restoreClosedSubagentIds`` so the live cap cannot be bypassed.
+    public private(set) var closedSubagentIds: [String] = []
+    /// O(1) membership mirror of ``closedSubagentIds`` for hot-path tombstone checks.
+    private var closedSubagentIdSet: Set<String> = []
+    /// Bound for *live* ``closedSubagentIds`` growth in long-lived Cursor sessions.
+    /// Persist restore does not apply this cap (see ``restoreClosedSubagentIds``).
+    public static let maxClosedSubagentIds = 256
     public var startTime: Date = Date()
     public var lastUserPrompt: String?
     public var lastAssistantMessage: String?
@@ -140,6 +149,62 @@ public struct SessionSnapshot: Sendable {
 
     public init(startTime: Date = Date()) {
         self.startTime = startTime
+    }
+
+    /// Record a closed subagent/Task id (no-op if already present). Evicts the
+    /// oldest entries when over ``maxClosedSubagentIds``.
+    ///
+    /// Callers must serialize access (today: `@MainActor` / main-queue session
+    /// mutation). The check-then-append is not atomic across threads the way
+    /// `Set.insert` was — do not call off the session-owning queue.
+    public mutating func recordClosedSubagentId(_ id: String) {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !closedSubagentIdSet.contains(trimmed) else { return }
+        closedSubagentIds.append(trimmed)
+        closedSubagentIdSet.insert(trimmed)
+        let overflow = closedSubagentIds.count - Self.maxClosedSubagentIds
+        if overflow > 0 {
+            for evicted in closedSubagentIds.prefix(overflow) {
+                closedSubagentIdSet.remove(evicted)
+            }
+            closedSubagentIds.removeFirst(overflow)
+        }
+    }
+
+    /// Drop a tombstone so the agent/Task may be folded or shown again.
+    /// Trims like ``recordClosedSubagentId`` so whitespace-padded ids clear.
+    public mutating func clearClosedSubagentId(_ id: String) {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard closedSubagentIdSet.remove(trimmed) != nil else { return }
+        closedSubagentIds.removeAll { $0 == trimmed }
+    }
+
+    /// O(1) tombstone check used on the subagent hook hot path.
+    /// Trims like ``recordClosedSubagentId`` / ``clearClosedSubagentId``.
+    public func hasClosedSubagentId(_ id: String) -> Bool {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return closedSubagentIdSet.contains(trimmed)
+    }
+
+    /// Restore persisted ids in file order **without** applying the live cap.
+    ///
+    /// Pre-cap builds wrote this array via `Set.sorted()` (lexicographic) — that
+    /// order is not recency, so keep-last-N on restore would drop arbitrary
+    /// tombstones and allow finished Tasks to re-fold. Disk size already bounds
+    /// memory; ``recordClosedSubagentId`` still caps *new* live growth.
+    public mutating func restoreClosedSubagentIds(_ ids: [String]) {
+        closedSubagentIds = []
+        closedSubagentIdSet = []
+        closedSubagentIds.reserveCapacity(ids.count)
+        closedSubagentIdSet.reserveCapacity(ids.count)
+        for id in ids {
+            let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !closedSubagentIdSet.contains(trimmed) else { continue }
+            closedSubagentIds.append(trimmed)
+            closedSubagentIdSet.insert(trimmed)
+        }
     }
 
     public static func normalizedSupportedSource(_ source: String?) -> String? {
@@ -840,7 +905,7 @@ public func reduceEvent(
         // Separate-mode Cursor Task Stop self-tombstones; a new prompt means relaunch.
         if let source = sessions[sessionId]?.source,
            source == "cursor" || source == "cursor-cli" {
-            sessions[sessionId]?.closedSubagentIds.remove(sessionId)
+            sessions[sessionId]?.clearClosedSubagentId(sessionId)
         }
         // Probe a wider set of field names + nested containers. Qwen Code (#103),
         // Hermes (#117), and most Claude forks put the prompt at "prompt" top-level,
@@ -981,7 +1046,7 @@ public func reduceEvent(
                childSessionId: sessionId,
                transcriptPath: sessions[sessionId]?.transcriptPath
            ) != nil {
-            sessions[sessionId]?.closedSubagentIds.insert(sessionId)
+            sessions[sessionId]?.recordClosedSubagentId(sessionId)
             // Drop process identity so a still-open IDE `_ppid` does not look like
             // a live Task after Stop when the card is later considered for merge.
             sessions[sessionId]?.cliPid = nil
@@ -1458,7 +1523,7 @@ private func ensureSubagent(
     // Only SubagentStart/SessionStart may reopen a closed agent id for most
     // providers. Cursor Tasks relaunch via UserPromptSubmit (see handleSubagentEvent).
     // Later tool/response hooks with the same agent_id must not revive it.
-    if sessions[sessionId]?.closedSubagentIds.contains(agentId) == true {
+    if sessions[sessionId]?.hasClosedSubagentId(agentId) == true {
         return false
     }
     if sessions[sessionId]?.subagents[agentId] == nil {
@@ -1483,7 +1548,7 @@ private func handleSubagentEvent(
     switch eventName {
     case "SubagentStart", "SessionStart":
         let agentType = subagentType(from: event)
-        sessions[sessionId]?.closedSubagentIds.remove(agentId)
+        sessions[sessionId]?.clearClosedSubagentId(agentId)
         sessions[sessionId]?.subagents[agentId] = SubagentState(
             agentId: agentId,
             agentType: agentType
@@ -1501,7 +1566,7 @@ private func handleSubagentEvent(
     case "UserPromptSubmit":
         // Cursor has no SessionStart for Tasks; beforeSubmitPrompt is the relaunch signal.
         if shouldReopenCursorSubagentOnPrompt(event: event, session: sessions[sessionId]) {
-            sessions[sessionId]?.closedSubagentIds.remove(agentId)
+            sessions[sessionId]?.clearClosedSubagentId(agentId)
         }
         guard ensureSubagent(sessions: &sessions, sessionId: sessionId, agentId: agentId, event: event) else {
             return true
@@ -1520,7 +1585,7 @@ private func handleSubagentEvent(
 
     case "SubagentStop", "Stop", "SessionEnd":
         sessions[sessionId]?.subagents.removeValue(forKey: agentId)
-        sessions[sessionId]?.closedSubagentIds.insert(agentId)
+        sessions[sessionId]?.recordClosedSubagentId(agentId)
         // If no more subagents, revert parent to processing (waiting for main thread to continue)
         if sessions[sessionId]?.subagents.isEmpty == true {
             if sessions[sessionId]?.status == .running && sessions[sessionId]?.currentTool == "Agent" {

--- a/Tests/CodeIslandCoreTests/ClosedSubagentIdsCapTests.swift
+++ b/Tests/CodeIslandCoreTests/ClosedSubagentIdsCapTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import CodeIslandCore
+
+final class ClosedSubagentIdsCapTests: XCTestCase {
+    func testHasClosedSubagentIdMatchesRecordedIds() {
+        var snapshot = SessionSnapshot()
+        snapshot.recordClosedSubagentId("a")
+        XCTAssertTrue(snapshot.hasClosedSubagentId("a"))
+        XCTAssertFalse(snapshot.hasClosedSubagentId("b"))
+        snapshot.clearClosedSubagentId("a")
+        XCTAssertFalse(snapshot.hasClosedSubagentId("a"))
+    }
+
+    func testHasClosedSubagentIdTrimsLikeRecord() {
+        var snapshot = SessionSnapshot()
+        snapshot.recordClosedSubagentId("  a  ")
+        XCTAssertTrue(snapshot.hasClosedSubagentId("  a  "))
+        XCTAssertTrue(snapshot.hasClosedSubagentId("a"))
+        XCTAssertFalse(snapshot.hasClosedSubagentId("   "))
+    }
+
+    func testClearClosedSubagentIdTrimsLikeRecord() {
+        var snapshot = SessionSnapshot()
+        snapshot.recordClosedSubagentId("  a  ")
+        XCTAssertEqual(snapshot.closedSubagentIds, ["a"])
+        snapshot.clearClosedSubagentId("  a  ")
+        XCTAssertTrue(snapshot.closedSubagentIds.isEmpty)
+    }
+
+    func testRecordClosedSubagentIdKeepsLastNInInsertionOrder() {
+        var snapshot = SessionSnapshot()
+        let limit = SessionSnapshot.maxClosedSubagentIds
+        for i in 0..<(limit + 10) {
+            snapshot.recordClosedSubagentId(String(format: "id-%03d", i))
+        }
+        XCTAssertEqual(snapshot.closedSubagentIds.count, limit)
+        XCTAssertEqual(snapshot.closedSubagentIds.first, "id-010")
+        XCTAssertEqual(snapshot.closedSubagentIds.last, String(format: "id-%03d", limit + 9))
+        XCTAssertFalse(snapshot.closedSubagentIds.contains("id-000"))
+        XCTAssertTrue(snapshot.closedSubagentIds.contains("id-010"))
+    }
+
+    func testRecordClosedSubagentIdIsIdempotent() {
+        var snapshot = SessionSnapshot()
+        snapshot.recordClosedSubagentId("a")
+        snapshot.recordClosedSubagentId("a")
+        XCTAssertEqual(snapshot.closedSubagentIds, ["a"])
+    }
+
+    func testClearClosedSubagentIdRemovesTombstone() {
+        var snapshot = SessionSnapshot()
+        snapshot.recordClosedSubagentId("a")
+        snapshot.recordClosedSubagentId("b")
+        snapshot.clearClosedSubagentId("a")
+        XCTAssertEqual(snapshot.closedSubagentIds, ["b"])
+    }
+
+    func testRestoreClosedSubagentIdsKeepsAllWithoutLiveCap() {
+        var snapshot = SessionSnapshot()
+        let ids = (0..<80).map { String(format: "p-%03d", $0) }
+        snapshot.restoreClosedSubagentIds(ids)
+        // Restore must not invent recency via keep-last-N (legacy files were
+        // lexicographically sorted).
+        XCTAssertEqual(snapshot.closedSubagentIds.count, 80)
+        XCTAssertEqual(snapshot.closedSubagentIds.first, "p-000")
+        XCTAssertEqual(snapshot.closedSubagentIds.last, "p-079")
+        XCTAssertTrue(snapshot.hasClosedSubagentId("p-000"))
+        XCTAssertTrue(snapshot.hasClosedSubagentId("p-079"))
+    }
+
+    func testRecordAfterLargeRestoreStillAppliesLiveCap() {
+        var snapshot = SessionSnapshot()
+        let over = SessionSnapshot.maxClosedSubagentIds + 10
+        let ids = (0..<over).map { String(format: "p-%03d", $0) }
+        snapshot.restoreClosedSubagentIds(ids)
+        XCTAssertEqual(snapshot.closedSubagentIds.count, over)
+        snapshot.recordClosedSubagentId("new-1")
+        XCTAssertEqual(snapshot.closedSubagentIds.count, SessionSnapshot.maxClosedSubagentIds)
+        XCTAssertEqual(snapshot.closedSubagentIds.last, "new-1")
+        XCTAssertFalse(snapshot.hasClosedSubagentId("p-000"))
+    }
+}

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -116,7 +116,8 @@ final class CursorSessionFoldingTests: XCTestCase {
         XCTAssertEqual(raw["agent_id"] as? String, "2528cb91-6379-48f2-aff8-40f4b804dafa")
         XCTAssertEqual(raw["agent_type"] as? String, "cursor-subagent")
         XCTAssertEqual(raw["_cursor_subagent"] as? Bool, true)
-        XCTAssertEqual(raw["_cursor_subagent_event"] as? String, "PreToolUse")
+        XCTAssertNil(raw["_cursor_subagent_session_id"])
+        XCTAssertNil(raw["_cursor_subagent_event"])
     }
 
     func testMergedCursorSubagentAfterAgentResponseDoesNotCompleteParent() throws {
@@ -196,7 +197,7 @@ final class CursorSessionFoldingTests: XCTestCase {
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .processing
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         var sessions = [parentId: parent]
 
         let data = try JSONSerialization.data(withJSONObject: [
@@ -306,7 +307,7 @@ final class CursorSessionFoldingTests: XCTestCase {
         var child = SessionSnapshot()
         child.source = "cursor"
         child.status = .idle
-        child.closedSubagentIds = [childId]
+        child.recordClosedSubagentId(childId)
         var sessions = [childId: child]
 
         let data = try JSONSerialization.data(withJSONObject: [
@@ -445,7 +446,7 @@ final class CursorSessionFoldingTests: XCTestCase {
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .processing
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         var sessions = [parentId: parent]
 
         let data = try JSONSerialization.data(withJSONObject: [
@@ -472,7 +473,7 @@ final class CursorSessionFoldingTests: XCTestCase {
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .processing
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         var sessions = [parentId: parent]
 
         let data = try JSONSerialization.data(withJSONObject: [

--- a/Tests/CodeIslandTests/AppStateCursorSubsessionTests.swift
+++ b/Tests/CodeIslandTests/AppStateCursorSubsessionTests.swift
@@ -271,7 +271,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         parent.status = .processing
         parent.providerSessionId = parentId
         parent.transcriptPath = transcriptPath
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         appState.sessions[parentId] = parent
 
         var staleChild = SessionSnapshot()
@@ -317,7 +317,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         child.status = .running
         child.currentTool = "Shell"
         child.transcriptPath = transcriptPath
-        child.closedSubagentIds = [childId]
+        child.recordClosedSubagentId(childId)
         appState.sessions[childId] = child
 
         XCTAssertTrue(appState.applyCursorSubsessionModeToKnownSessions())
@@ -445,7 +445,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         child.source = "cursor"
         child.status = .running
         child.transcriptPath = transcriptPath
-        child.closedSubagentIds = [childId]
+        child.recordClosedSubagentId(childId)
         appState.sessions[childId] = child
 
         XCTAssertTrue(appState.applyCursorSubsessionModeToKnownSessions())
@@ -516,7 +516,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         child.source = "cursor"
         child.status = .idle
         child.transcriptPath = transcriptPath
-        child.closedSubagentIds = [childId]
+        child.recordClosedSubagentId(childId)
         appState.sessions[childId] = child
 
         XCTAssertTrue(appState.applyCursorSubsessionModeToKnownSessions())
@@ -556,7 +556,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         child.status = .idle
         child.transcriptPath = transcriptPath
         // Separate-mode Stop self-tombstone + live IDE `_ppid` must not revive as running.
-        child.closedSubagentIds = [childId]
+        child.recordClosedSubagentId(childId)
         child.cliPid = getpid()
         appState.sessions[childId] = child
 
@@ -629,7 +629,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .processing
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         appState.sessions[parentId] = parent
 
         let data = try JSONSerialization.data(withJSONObject: [
@@ -660,7 +660,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .processing
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         appState.sessions[parentId] = parent
 
         let data = try JSONSerialization.data(withJSONObject: [
@@ -689,7 +689,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .processing
-        parent.closedSubagentIds = [childId]
+        parent.recordClosedSubagentId(childId)
         appState.sessions[parentId] = parent
 
         let data = try JSONSerialization.data(withJSONObject: [
@@ -828,7 +828,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
 
         // Simulate Stop removing the Task between enqueue and deny.
         appState.sessions[parentId]?.subagents.removeValue(forKey: childId)
-        appState.sessions[parentId]?.closedSubagentIds.insert(childId)
+        appState.sessions[parentId]?.recordClosedSubagentId(childId)
 
         appState.handleBuddyControlCommand(.denyCurrentPermission)
         _ = await responseTask.value
@@ -880,7 +880,7 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         var child = SessionSnapshot()
         child.source = "cursor"
         child.status = .idle
-        child.closedSubagentIds = [childId]
+        child.recordClosedSubagentId(childId)
         appState.sessions[childId] = child
 
         let data = try JSONSerialization.data(withJSONObject: [

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -489,6 +489,79 @@ final class ConfigInstallerTests: XCTestCase {
         XCTAssertFalse(uninstalled.contains("codeisland-bridge"), "CodeIsland hooks should be removed after uninstall")
     }
 
+    /// Migrated users may keep hooks under ~/.kimi while ~/.kimi-code/config.toml
+    /// has none. Status must follow the preferred (install) path only — not ANY home.
+    func testKimiHooksInstalledIgnoresLegacyWhenPreferredPathLacksHooks() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        let modernPath = tempDir.appendingPathComponent("modern-config.toml").path
+        let legacyPath = tempDir.appendingPathComponent("legacy-config.toml").path
+        // Preferred home config: present but no CodeIsland hooks.
+        fm.createFile(atPath: modernPath, contents: Data("model = \"kimi\"\n".utf8))
+
+        let events = ConfigInstaller.defaultEvents(for: .kimi)
+        let legacyCli = CLIConfig(
+            name: "Kimi Code CLI",
+            source: "kimi",
+            configPath: legacyPath,
+            configKey: "hooks",
+            format: .kimi,
+            events: events
+        )
+        XCTAssertTrue(ConfigInstaller.installKimiHooks(cli: legacyCli, fm: fm))
+        XCTAssertTrue(
+            ConfigInstaller.isKimiHooksInstalled(at: legacyPath, cli: legacyCli, fm: fm),
+            "Sanity: legacy path with hooks reports installed"
+        )
+        XCTAssertFalse(
+            ConfigInstaller.isKimiHooksInstalled(at: modernPath, cli: legacyCli, fm: fm),
+            "Preferred path without hooks must not report installed just because legacy has hooks"
+        )
+    }
+
+    /// Locks status to a single install-target path (no modern∪legacy OR).
+    func testKimiHooksStatusConfigPathsIsExactlyCliFullPath() {
+        let preferred = "/tmp/hermetic-kimi-code/config.toml"
+        let cli = CLIConfig(
+            name: "Kimi Code CLI",
+            source: "kimi",
+            configPath: preferred,
+            configKey: "hooks",
+            format: .kimi,
+            events: ConfigInstaller.defaultEvents(for: .kimi)
+        )
+        let paths = ConfigInstaller.kimiHooksStatusConfigPaths(for: cli)
+        XCTAssertEqual(paths, [preferred])
+        XCTAssertEqual(paths.count, 1, "Status must never OR multiple kimi homes")
+        XCTAssertFalse(
+            paths.contains { $0.hasSuffix("/.kimi/config.toml") && $0 != preferred },
+            "Must not quietly include legacy home alongside preferred path"
+        )
+    }
+
+    func testKimiHooksInstalledTrueWhenPreferredPathHasHooks() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        let configPath = tempDir.appendingPathComponent("config.toml").path
+        let events = ConfigInstaller.defaultEvents(for: .kimi)
+        let cli = CLIConfig(
+            name: "Kimi Code CLI",
+            source: "kimi",
+            configPath: configPath,
+            configKey: "hooks",
+            format: .kimi,
+            events: events
+        )
+        XCTAssertTrue(ConfigInstaller.installKimiHooks(cli: cli, fm: fm))
+        XCTAssertTrue(ConfigInstaller.isKimiHooksInstalled(at: configPath, cli: cli, fm: fm))
+    }
+
     func testMergeCocoHooksAppendsHooksSectionWhenMissing() {
         let original = "model:\n    name: GPT-5.4\n"
 

--- a/Tests/CodeIslandTests/HookServerCursorProbeTests.swift
+++ b/Tests/CodeIslandTests/HookServerCursorProbeTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import CodeIsland
+
+@MainActor
+final class HookServerCursorProbeTests: XCTestCase {
+    func testMayNeedCursorRequiresExactSourceAndAgentTranscripts() {
+        let path = "/x/agent-transcripts/p/c.jsonl"
+
+        let compactCursor = Data(#"{"_source":"cursor","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: compactCursor))
+
+        let spacedCursor = Data(#"{"_source": "cursor","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: spacedCursor))
+
+        let spaceBeforeColon = Data(#"{"_source" :"cursor","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: spaceBeforeColon))
+
+        let spaceBothSides = Data(#"{"_source" : "cursor","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: spaceBothSides))
+
+        let compactCli = Data(#"{"_source":"cursor-cli","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: compactCli))
+
+        let spacedCli = Data(#"{"_source": "cursor-cli","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: spacedCli))
+
+        // `\u0063` = c — literal regex misses; JSON fallback must still accept.
+        let unicodeCursor = Data(
+            #"{"_source":"\u0063ursor","transcript_path":"\#(path)"}"#.utf8
+        )
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: unicodeCursor))
+
+        let missingSourceKey = Data(#"{"source":"cursor","transcript_path":"\#(path)"}"#.utf8)
+        XCTAssertFalse(
+            HookServer.mayNeedCursorSubsessionRouting(data: missingSourceKey),
+            "Bare source without _source must not force a Cursor JSON parse"
+        )
+
+        let cursorInTextOnly = Data(#"{"text":"move cursor here","path":"\#(path)"}"#.utf8)
+        XCTAssertFalse(HookServer.mayNeedCursorSubsessionRouting(data: cursorInTextOnly))
+
+        let wrongSource = Data(
+            #"{"_source":"claude","text":"cursor","transcript_path":"\#(path)"}"#.utf8
+        )
+        XCTAssertFalse(
+            HookServer.mayNeedCursorSubsessionRouting(data: wrongSource),
+            "Unrelated _source plus bare cursor text must not force a parse"
+        )
+
+        // Non-cursor + agent-transcripts + unrelated `\u` must not claim Cursor.
+        let wrongSourceWithUnicodeElsewhere = Data(
+            #"{"_source":"claude","text":"\u0041","transcript_path":"\#(path)"}"#.utf8
+        )
+        XCTAssertFalse(
+            HookServer.mayNeedCursorSubsessionRouting(data: wrongSourceWithUnicodeElsewhere)
+        )
+
+        let noTranscripts = Data(#"{"_source":"cursor","session_id":"abc"}"#.utf8)
+        XCTAssertFalse(HookServer.mayNeedCursorSubsessionRouting(data: noTranscripts))
+    }
+}

--- a/Tests/CodeIslandTests/KimiCodeSessionDiscoveryTests.swift
+++ b/Tests/CodeIslandTests/KimiCodeSessionDiscoveryTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import CodeIsland
+
+final class KimiCodeSessionDiscoveryTests: XCTestCase {
+    func testDiscoverKimiCodeSessionFromIndexMatchesWorkDirAndReadsWire() throws {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let kimiCode = home.appendingPathComponent(".kimi-code")
+        let sessionDir = kimiCode.appendingPathComponent("sessions/sid-1")
+        let agentsMain = sessionDir.appendingPathComponent("agents/main")
+        try fm.createDirectory(at: agentsMain, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: home) }
+
+        let cwd = "/tmp/project-a"
+        let indexLine = """
+        {"sessionId":"sid-1","sessionDir":"\(sessionDir.path)","workDir":"\(cwd)"}
+        """
+        try indexLine.write(
+            to: kimiCode.appendingPathComponent("session_index.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"status":"running"}"#.write(
+            to: sessionDir.appendingPathComponent("state.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let wire = [
+            #"{"type":"turn.prompt","input":[{"type":"text","text":"Hello kimi"}],"origin":{"kind":"user"}}"#,
+            #"{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"Hi there"}}}"#,
+        ].joined(separator: "\n")
+        try wire.write(
+            to: agentsMain.appendingPathComponent("wire.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let discovered = AppState.discoverKimiCodeSessionFromIndexForTesting(
+            home: home.path,
+            cwd: cwd,
+            pid: 4242,
+            processStart: Date(),
+            fm: fm
+        )
+
+        let match = try XCTUnwrap(discovered)
+        XCTAssertEqual(match.sessionId, "sid-1")
+        XCTAssertEqual(match.cwd, cwd)
+        XCTAssertEqual(match.pid, 4242)
+        XCTAssertEqual(match.source, "kimi")
+        XCTAssertEqual(match.messageTexts, ["Hello kimi", "Hi there"])
+    }
+
+    func testDiscoverKimiCodeSessionFromIndexIgnoresOtherWorkDirs() throws {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let kimiCode = home.appendingPathComponent(".kimi-code")
+        let sessionDir = kimiCode.appendingPathComponent("sessions/sid-other")
+        try fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: home) }
+
+        try #"{"sessionId":"sid-other","sessionDir":"\#(sessionDir.path)","workDir":"/tmp/other"}"#
+            .write(to: kimiCode.appendingPathComponent("session_index.jsonl"), atomically: true, encoding: .utf8)
+        try #"{"status":"running"}"#
+            .write(to: sessionDir.appendingPathComponent("state.json"), atomically: true, encoding: .utf8)
+
+        let discovered = AppState.discoverKimiCodeSessionFromIndexForTesting(
+            home: home.path,
+            cwd: "/tmp/project-a",
+            pid: 1,
+            processStart: Date(),
+            fm: fm
+        )
+        XCTAssertNil(discovered)
+    }
+
+    func testDiscoverKimiCodeSessionFromIndexRejectsStaleState() throws {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let kimiCode = home.appendingPathComponent(".kimi-code")
+        let sessionDir = kimiCode.appendingPathComponent("sessions/sid-stale")
+        try fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: home) }
+
+        let cwd = "/tmp/project-stale"
+        try #"{"sessionId":"sid-stale","sessionDir":"\#(sessionDir.path)","workDir":"\#(cwd)"}"#
+            .write(to: kimiCode.appendingPathComponent("session_index.jsonl"), atomically: true, encoding: .utf8)
+
+        let stateURL = sessionDir.appendingPathComponent("state.json")
+        try #"{"status":"idle"}"#.write(to: stateURL, atomically: true, encoding: .utf8)
+        let old = Date().addingTimeInterval(-3600)
+        try fm.setAttributes([.modificationDate: old], ofItemAtPath: stateURL.path)
+
+        let discovered = AppState.discoverKimiCodeSessionFromIndexForTesting(
+            home: home.path,
+            cwd: cwd,
+            pid: 1,
+            processStart: Date(),
+            fm: fm
+        )
+        XCTAssertNil(discovered)
+    }
+
+    /// Multi-line index: same workDir → pick the newest state.json mtime.
+    func testDiscoverKimiCodeSessionFromIndexPicksNewestAmongMatchingLines() throws {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let kimiCode = home.appendingPathComponent(".kimi-code")
+        let olderDir = kimiCode.appendingPathComponent("sessions/sid-old")
+        let newerDir = kimiCode.appendingPathComponent("sessions/sid-new")
+        let otherDir = kimiCode.appendingPathComponent("sessions/sid-other")
+        try fm.createDirectory(at: olderDir.appendingPathComponent("agents/main"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: newerDir.appendingPathComponent("agents/main"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: otherDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: home) }
+
+        let cwd = "/tmp/project-multi"
+        let index = [
+            #"{"sessionId":"sid-old","sessionDir":"\#(olderDir.path)","workDir":"\#(cwd)"}"#,
+            #"{"sessionId":"sid-other","sessionDir":"\#(otherDir.path)","workDir":"/tmp/elsewhere"}"#,
+            #"{"sessionId":"sid-new","sessionDir":"\#(newerDir.path)","workDir":"\#(cwd)"}"#,
+        ].joined(separator: "\n")
+        try index.write(
+            to: kimiCode.appendingPathComponent("session_index.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let olderState = olderDir.appendingPathComponent("state.json")
+        let newerState = newerDir.appendingPathComponent("state.json")
+        try #"{"status":"idle"}"#.write(to: olderState, atomically: true, encoding: .utf8)
+        try #"{"status":"running"}"#.write(to: newerState, atomically: true, encoding: .utf8)
+        try fm.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-120)],
+            ofItemAtPath: olderState.path
+        )
+        try fm.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: newerState.path
+        )
+
+        let discovered = AppState.discoverKimiCodeSessionFromIndexForTesting(
+            home: home.path,
+            cwd: cwd,
+            pid: 7,
+            processStart: Date(),
+            fm: fm
+        )
+        XCTAssertEqual(discovered?.sessionId, "sid-new")
+    }
+
+    /// Without processStart, freshness window is 30s (not 300s).
+    func testDiscoverKimiCodeSessionFromIndexNilProcessStartUsesShortFreshnessWindow() throws {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let kimiCode = home.appendingPathComponent(".kimi-code")
+        let sessionDir = kimiCode.appendingPathComponent("sessions/sid-nil-start")
+        try fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: home) }
+
+        let cwd = "/tmp/project-nil-start"
+        try #"{"sessionId":"sid-nil-start","sessionDir":"\#(sessionDir.path)","workDir":"\#(cwd)"}"#
+            .write(to: kimiCode.appendingPathComponent("session_index.jsonl"), atomically: true, encoding: .utf8)
+
+        let stateURL = sessionDir.appendingPathComponent("state.json")
+        try #"{"status":"idle"}"#.write(to: stateURL, atomically: true, encoding: .utf8)
+        // Older than 30s → rejected when processStart is nil; would still pass the
+        // 300s window used when processStart is set.
+        try fm.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-90)],
+            ofItemAtPath: stateURL.path
+        )
+
+        let rejected = AppState.discoverKimiCodeSessionFromIndexForTesting(
+            home: home.path,
+            cwd: cwd,
+            pid: 1,
+            processStart: nil,
+            fm: fm
+        )
+        XCTAssertNil(rejected)
+
+        let acceptedWithProcessStart = AppState.discoverKimiCodeSessionFromIndexForTesting(
+            home: home.path,
+            cwd: cwd,
+            pid: 1,
+            processStart: Date().addingTimeInterval(-120),
+            fm: fm
+        )
+        XCTAssertEqual(acceptedWithProcessStart?.sessionId, "sid-nil-start")
+    }
+}

--- a/Tests/CodeIslandTests/KimiTranscriptTests.swift
+++ b/Tests/CodeIslandTests/KimiTranscriptTests.swift
@@ -47,4 +47,85 @@ final class KimiTranscriptTests: XCTestCase {
         XCTAssertEqual(messages.map(\.text), ["Legacy hi", "Legacy bye"])
         XCTAssertEqual(messages.map(\.isUser), [true, false])
     }
+
+    /// Prefer turn.prompt when both exist; append-first must not duplicate the user line.
+    func testKimiCodeWirePrefersTurnPromptOverPrecedingAppendMessage() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let path = dir.appendingPathComponent("wire.jsonl").path
+        // Reverse of the usual order: append_message before turn.prompt.
+        let lines = [
+            #"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"From append"}]}}"#,
+            #"{"type":"turn.prompt","input":[{"type":"text","text":"From prompt"}],"origin":{"kind":"user"}}"#,
+            #"{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"Reply"}}}"#,
+        ]
+        try lines.joined(separator: "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        let messages = AppState.readRecentFromKimiTranscript(path: path).1
+        XCTAssertEqual(messages.map(\.text), ["From prompt", "Reply"])
+        XCTAssertEqual(messages.map(\.isUser), [true, false])
+    }
+
+    /// Normal order: turn.prompt first; append_message for the same turn is ignored.
+    func testKimiCodeWireIgnoresAppendWhenTurnPromptAlreadyOpen() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let path = dir.appendingPathComponent("wire.jsonl").path
+        let lines = [
+            #"{"type":"turn.prompt","input":[{"type":"text","text":"From prompt"}],"origin":{"kind":"user"}}"#,
+            #"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"From append"}]}}"#,
+            #"{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"Reply"}}}"#,
+        ]
+        try lines.joined(separator: "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        let messages = AppState.readRecentFromKimiTranscript(path: path).1
+        XCTAssertEqual(messages.map(\.text), ["From prompt", "Reply"])
+        XCTAssertEqual(messages.map(\.isUser), [true, false])
+    }
+
+    /// Consecutive turn.prompt without assistant must still flush the first user line.
+    func testKimiCodeWireConsecutiveTurnPromptsDoNotDropPriorUser() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let path = dir.appendingPathComponent("wire.jsonl").path
+        let lines = [
+            #"{"type":"turn.prompt","input":[{"type":"text","text":"First"}],"origin":{"kind":"user"}}"#,
+            #"{"type":"turn.prompt","input":[{"type":"text","text":"Second"}],"origin":{"kind":"user"}}"#,
+            #"{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"Answer"}}}"#,
+        ]
+        try lines.joined(separator: "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        let messages = AppState.readRecentFromKimiTranscript(path: path).1
+        XCTAssertEqual(messages.map(\.text), ["First", "Second", "Answer"])
+        XCTAssertEqual(messages.map(\.isUser), [true, true, false])
+    }
+
+    /// Empty turn.prompt after append_message must keep the append user text.
+    func testKimiCodeWireEmptyTurnPromptDoesNotWipePrecedingAppend() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let path = dir.appendingPathComponent("wire.jsonl").path
+        let lines = [
+            #"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"From append"}]}}"#,
+            #"{"type":"turn.prompt","input":[],"origin":{"kind":"user"}}"#,
+            #"{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"Reply"}}}"#,
+        ]
+        try lines.joined(separator: "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        let messages = AppState.readRecentFromKimiTranscript(path: path).1
+        XCTAssertEqual(messages.map(\.text), ["From append", "Reply"])
+        XCTAssertEqual(messages.map(\.isUser), [true, false])
+    }
 }


### PR DESCRIPTION
## Summary

Follow-ups for the LOW notes on [#262](https://github.com/wxtsky/CodeIsland/pull/262) and [#274](https://github.com/wxtsky/CodeIsland/pull/274):

- **Closed-subagent ids (#262 b):** `closedSubagentIds` is an ordered list (newest last) with a live keep-last-**256** cap, O(1) `hasClosedSubagentId`, and mutate-only APIs. Persist keeps insertion order (no `.sorted()`). Restore loads **all** disk ids (no fake-recency trim); the live cap applies on new `record` only. Permission/Question suppress uses `hasClosedSubagentId`.
- **AppState teardown (#262 a):** Timers + FSEvents tear down in one main-queue hop from `deinit`; `stopSessionDiscovery` also invalidates `rotationTimer`.
- **Cursor probe (#262 c):** Require `agent-transcripts` plus `_source` of `cursor` / `cursor-cli` (compact literals → whitespace-tolerant regex → JSON only if `\u` is present). Drop write-only `_cursor_subagent_session_id` / `_cursor_subagent_event`.
- **Kimi hooks status (#274 c):** Installed badge checks only `cli.fullPath` (install target). Uninstall still scrubs modern + legacy.
- **Kimi wire (#274 b):** Prefer `turn.prompt` over a preceding `context.append_message`; empty `turn.prompt` does not wipe append text; consecutive prompts do not drop the prior user line.
- **Kimi discovery (#274 a):** Unit coverage for `discoverKimiCodeSessionFromIndex` via a test seam (private type unchanged).

## 中文说明

针对 [#262](https://github.com/wxtsky/CodeIsland/pull/262) 与 [#274](https://github.com/wxtsky/CodeIsland/pull/274) 的 LOW 跟进：

- **Closed-subagent ids（#262 b）：** `closedSubagentIds` 改为有序数组（最新在末尾），运行时 keep-last-**256**，O(1) `hasClosedSubagentId`，仅经 mutate API 写入。持久化保留插入序（不再 `.sorted()`）。restore **保留磁盘全部 id**（不做假 recency 截断）；cap 只在新的 `record` 时生效。Permission/Question 抑制改走 `hasClosedSubagentId`。
- **AppState teardown（#262 a）：** `deinit` 在一次主线程 hop 内拆掉 Timer + FSEvents；`stopSessionDiscovery` 也会 invalidate `rotationTimer`。
- **Cursor 探针（#262 c）：** 需要 `agent-transcripts` 且 `_source` 为 `cursor` / `cursor-cli`（compact 字面量 → 冒号两侧空白的 regex → 仅当存在 `\u` 时才 JSON）。删除只写字段 `_cursor_subagent_session_id` / `_cursor_subagent_event`。
- **Kimi hooks 状态（#274 c）：**「已安装」只检查 `cli.fullPath`（安装目标）。卸载仍同时清理 modern + legacy。
- **Kimi wire（#274 b）：** 若先有 `context.append_message`，后续 `turn.prompt` 优先替换用户文本；空的 `turn.prompt` 不擦掉 append 内容；连续 `turn.prompt` 不会丢掉上一轮用户行。
- **Kimi discovery（#274 a）：** 为 `discoverKimiCodeSessionFromIndex` 增加单测（经 test seam；`DiscoveredSession` 仍保持 private）。

## Test Plan

- [x] `ClosedSubagentIdsCapTests`
- [x] `HookServerCursorProbeTests` (compact / spaced / `\u` / negatives)
- [x] `ConfigInstallerTests` (status path lock + migration false-positive)
- [x] `KimiCodeSessionDiscoveryTests`
- [x] `KimiTranscriptTests` (both orders, consecutive prompts, empty prompt)
- [x] Related: `CursorSessionFoldingTests`, `AppStateCursorSubsessionTests`