### PR TITLE
fix(pi): skip terminal permission-gate after island allow

### DIFF
--- a/Sources/CodeIsland/ConfigInstaller.swift
+++ b/Sources/CodeIsland/ConfigInstaller.swift
@@ -2821,7 +2821,11 @@ struct ConfigInstaller {
     // MARK: - pi Extension
 
     /// Current pi extension version — bump when codeisland-pi.ts changes.
-    private static let piExtensionVersion = "v2"
+    private static let piExtensionVersion = "v3"
+
+    /// Current OMP extension version — keep independent of pi (OMP reuses the
+    /// "CodeIsland pi extension" banner but ships its own resource file).
+    private static let ompExtensionVersion = "v2"
 
     private static func piExtensionSource() -> String? {
         if let url = Bundle.appModule.url(forResource: "codeisland-pi", withExtension: "ts", subdirectory: "Resources"),
@@ -2902,7 +2906,14 @@ struct ConfigInstaller {
         ompExtensionPath: String = ompExtensionPath,
         fm: FileManager
     ) -> Bool {
-        isPiExtensionInstalled(piExtensionPath: ompExtensionPath, fm: fm)
+        guard fm.fileExists(atPath: ompExtensionPath),
+              let data = fm.contents(atPath: ompExtensionPath),
+              let content = String(data: data, encoding: .utf8)
+        else { return false }
+        // OMP ships a separate resource; do not share piExtensionVersion or a
+        // pi-only bump would force a false "needs repair" for healthy OMP installs.
+        return content.contains("CodeIsland pi extension")
+            && content.contains("// version: \(ompExtensionVersion)")
     }
 
     // MARK: - OpenClaw plugin (#235)

--- a/Sources/CodeIsland/Resources/codeisland-pi.ts
+++ b/Sources/CodeIsland/Resources/codeisland-pi.ts
@@ -1,5 +1,5 @@
 // CodeIsland pi extension
-// version: v2
+// version: v3
 
 /**
  * @fileoverview CodeIsland Integration Extension.
@@ -28,7 +28,15 @@
  *   Dangerous bash commands (`rm -rf`, `sudo`, `chmod 777`) are intercepted and
  *   sent as a blocking PermissionRequest via the codeisland-bridge binary. The
  *   extension waits for CodeIsland's decision and returns allow/block accordingly.
- *   This replaces the built-in permission-gate.ts when CodeIsland is active.
+ *
+ *   On allow, it records the toolCallId on globalThis.__codeislandAllowedToolCalls
+ *   so a co-installed permission-gate.ts can skip its terminal Yes/No dialog
+ *   (avoids double confirmation). On timeout / unreachable CodeIsland, no marker
+ *   is set and permission-gate remains the fallback prompt.
+ *
+ *   Note: pi runs every extension tool_call handler; only `{ block: true }` short-
+ *   circuits. An island allow alone does not disable permission-gate — the marker
+ *   is the coordination point. See companion skip check in permission-gate.ts.
  *
  * Installation:
  *   Drop this file in ~/.pi/agent/extensions/ — it is auto-discovered.
@@ -490,7 +498,19 @@ export default function codeislandExtension(pi: ExtensionAPI) {
         return { block: true, reason: "Blocked by CodeIsland" };
       }
 
-      // Approved — fall through to normal PreToolUse event below.
+      // Island allow: mark this tool call so permission-gate skips the TUI prompt.
+      // Only mark explicit allow — timeout / null must still fall through to the gate.
+      if (behavior?.behavior === "allow" && event.toolCallId) {
+        const g = globalThis as typeof globalThis & {
+          __codeislandAllowedToolCalls?: Set<string>;
+        };
+        if (!g.__codeislandAllowedToolCalls) {
+          g.__codeislandAllowedToolCalls = new Set();
+        }
+        g.__codeislandAllowedToolCalls.add(event.toolCallId);
+      }
+
+      // Approved or unreachable — fall through to PreToolUse / permission-gate.
     }
 
     // Non-blocking PreToolUse for all other tool calls.

--- a/Tests/CodeIslandTests/ConfigInstallerTests.swift
+++ b/Tests/CodeIslandTests/ConfigInstallerTests.swift
@@ -1288,7 +1288,8 @@ hooks:
 
         let contents = try String(contentsOf: piExtensionPath)
         XCTAssertTrue(contents.contains("CodeIsland pi extension"))
-        XCTAssertTrue(contents.contains("// version: v2"))
+        XCTAssertTrue(contents.contains("// version: v3"))
+        XCTAssertTrue(contents.contains("__codeislandAllowedToolCalls"))
         XCTAssertTrue(contents.contains("@earendil-works/pi-coding-agent"))
         XCTAssertTrue(ConfigInstaller.isPiExtensionInstalled(piExtensionPath: piExtensionPath.path, fm: fm))
     }


### PR DESCRIPTION
## Summary

Fixes #286.

On pi, approving a dangerous bash command on the Dynamic Island still left a second Yes/No confirmation from a co-installed `permission-gate.ts`.

pi runs every extension `tool_call` handler; only `{ block: true }` short-circuits. Island allow previously returned `undefined`, so `permission-gate` always re-prompted.

## Changes

### 1. `codeisland-pi.ts` (`v2` → `v3`)

- On explicit island `allow`, record `event.toolCallId` on `globalThis.__codeislandAllowedToolCalls`.
- Timeout / null response does **not** set the marker (terminal gate remains fallback).
- Fix the header comment that incorrectly claimed the extension "replaces" `permission-gate.ts`.

### 2. Installer version bump

- `piExtensionVersion`: `v2` → `v3` so repair reinstalls the fixed resource.

### 3. OMP version independence (regression guard)

- `isOmpExtensionInstalled` previously reused `piExtensionVersion`.
- A pi-only bump would false-flag healthy OMP installs as needing repair.
- Introduce independent `ompExtensionVersion = "v2"` and check it directly.

### 4. Tests

- Assert installed pi extension contains `// version: v3` and `__codeislandAllowedToolCalls`.
- Leave OMP expectation at `v2`.

## Coordination with user-managed `permission-gate.ts`

CodeIsland does not own `permission-gate.ts` (user extension). The intended companion check is:

```ts
const allowed = (globalThis as any).__codeislandAllowedToolCalls as Set<string> | undefined;
if (event.toolCallId && allowed?.has(event.toolCallId)) {
  allowed.delete(event.toolCallId);
  return undefined; // skip TUI prompt
}
```

Without that skip, the island still prompts once, but the terminal gate will still ask. With both sides, island Allow is sufficient for that tool call.

## Degradation matrix

| Scenario | Result |
|---|---|
| Island Allow | marker set → compatible gate skips TUI |
| Island Deny | `{ block: true }` (unchanged) |
| Island timeout / offline | no marker → terminal gate still prompts |
| No `permission-gate.ts` | behavior unchanged (island only) |

## Related

- Same dual-entry confirmation class as #264 (OMP Ask race), but for pi bash permissions.
- #196 / #197 pi integration.

## Verification

- Diff review of the three changed files.
- Local pi install already uses the same marker protocol with a companion `permission-gate.ts` skip.
- Installer/unit tests updated for `v3` marker content.
- Full `swift test` not run in this environment (no local git checkout / Xcode build path for this fork via API-only push). Happy to iterate on CI.

```bash
# after local checkout
swift test --filter ConfigInstallerTests
```
