### PR TITLE
fix(activator): guard Terminal.app tab enumeration against tab-less windows

### DIFF
--- a/Sources/CodeIsland/TerminalActivator.swift
+++ b/Sources/CodeIsland/TerminalActivator.swift
@@ -703,19 +703,25 @@ struct TerminalActivator {
             set found to false
 
             -- Strategy 1: precise tty match
+            -- `tabs of w` is wrapped in its own try: Terminal.app can keep a window
+            -- with no tabs at all (invisible utility window: name "", visible false).
+            -- Asking it for tabs raises -10000, which would abort the whole tell block
+            -- and skip every later window plus the final `activate`.
             if targetTty is not "" then
                 repeat with w in windows
-                    repeat with t in tabs of w
-                        try
-                            if tty of t is targetTty then
-                                if miniaturized of w then set miniaturized of w to false
-                                set selected tab of w to t
-                                set index of w to 1
-                                set found to true
-                                exit repeat
-                            end if
-                        end try
-                    end repeat
+                    try
+                        repeat with t in tabs of w
+                            try
+                                if tty of t is targetTty then
+                                    if miniaturized of w then set miniaturized of w to false
+                                    set selected tab of w to t
+                                    set index of w to 1
+                                    set found to true
+                                    exit repeat
+                                end if
+                            end try
+                        end repeat
+                    end try
                     if found then exit repeat
                 end repeat
             end if
@@ -723,17 +729,19 @@ struct TerminalActivator {
             -- Strategy 2: auto tab title contains the cwd folder name
             if not found and targetDir is not "" then
                 repeat with w in windows
-                    repeat with t in tabs of w
-                        try
-                            if (name of t as text) contains targetDir then
-                                if miniaturized of w then set miniaturized of w to false
-                                set selected tab of w to t
-                                set index of w to 1
-                                set found to true
-                                exit repeat
-                            end if
-                        end try
-                    end repeat
+                    try
+                        repeat with t in tabs of w
+                            try
+                                if (name of t as text) contains targetDir then
+                                    if miniaturized of w then set miniaturized of w to false
+                                    set selected tab of w to t
+                                    set index of w to 1
+                                    set found to true
+                                    exit repeat
+                                end if
+                            end try
+                        end repeat
+                    end try
                     if found then exit repeat
                 end repeat
             end if
@@ -741,17 +749,19 @@ struct TerminalActivator {
             -- Strategy 3: user-set custom title
             if not found and targetDir is not "" then
                 repeat with w in windows
-                    repeat with t in tabs of w
-                        try
-                            if custom title of t contains targetDir then
-                                if miniaturized of w then set miniaturized of w to false
-                                set selected tab of w to t
-                                set index of w to 1
-                                set found to true
-                                exit repeat
-                            end if
-                        end try
-                    end repeat
+                    try
+                        repeat with t in tabs of w
+                            try
+                                if custom title of t contains targetDir then
+                                    if miniaturized of w then set miniaturized of w to false
+                                    set selected tab of w to t
+                                    set index of w to 1
+                                    set found to true
+                                    exit repeat
+                                end if
+                            end try
+                        end repeat
+                    end try
                     if found then exit repeat
                 end repeat
             end if


### PR DESCRIPTION
## Summary

Clicking a session that lives in anything but the first Terminal.app window did
nothing at all — no tab switch, no window raise. The Terminal.app activation
script aborts halfway through whenever `windows` contains a window whose tabs
can't be read.

Fixes #294.

## Root cause

`Sources/CodeIsland/TerminalActivator.swift` → `activateTerminalApp(ttyPath:cwd:)`.
All three matching strategies iterate windows like this:

```applescript
repeat with w in windows
    repeat with t in tabs of w      -- not guarded
        try
            if tty of t is targetTty then …
        end try
    end repeat
```

The `try` covers the comparison but not `tabs of w`. Terminal.app can keep a
window that has no tabs at all — an invisible utility window (`name ""`,
`visible false`) that lives for the whole lifetime of the Terminal process.
Asking it for `tabs` raises `-10000`, which tears down the entire
`tell application "Terminal"` block. Two consequences:

1. Every window enumerated after that one is skipped, so its session is never
   found by any of the three strategies.
2. The final `activate` on line 772 is never reached either — unlike the iTerm2
   and Ghostty branches, this block has no outer `try`, so the failure also
   costs the app-level raise that would otherwise be the visible fallback.

Observed state (macOS 14.1, Terminal.app 2.14):

```
count windows → 3
window 1: id=34582 visible=true  tabs=1   (session A, /dev/ttys136)
window 2: id=591   visible=false tabs=ERR ← aborts the loop here
window 3: id=34663 visible=true  tabs=1   (session B, /dev/ttys138)
```

Running the enumeration exactly as the app does it:

```
/dev/ttys136 → found=true
/dev/ttys138 → FAILED: Terminal got an error: AppleEvent handler failed.
```

From the user's side this is indistinguishable from the Strategy 1 misfire
fixed in #124: one session jumps, the others silently do nothing.

## Fix

Wrap each window's tab enumeration in its own `try`, in all three strategies —
the same hardening #202 applied to iTerm2's `select <window>`.

Semantics are unchanged: `exit repeat` still refers to the tab loop, and
`if found then exit repeat` stays outside the guard, so the outer loop still
stops at the first match. Only windows that cannot be read are skipped.

## Why not filter on `visible of w`

The issue originally suggested skipping invisible windows, and this PR
deliberately doesn't. Minimized windows are tracked by the separate
`miniaturized` property, and the comment on lines 775–777 documents that on some
macOS 14 builds minimized windows fall out of `windows` entirely — a visibility
filter would risk regressing the deminiaturize path added for #124. A bare `try`
skips exactly the unreadable windows and nothing else.

## Test plan

- [x] Extracted the patched AppleScript from the Swift literal with real values
      substituted (`/dev/ttys136`, `projects`) and compiled it with `osacompile`
      — nesting of `try`/`repeat` is valid
- [x] Ran the patched script against a live Terminal.app: no error, correct tab
      selected, Terminal raised
- [x] Verified the pre-patch script fails on the same window set with
      `AppleEvent handler failed` while the patched one returns `found=true`
- [x] `swift build`

## Related

- #294 — the bug report
- #202 — same class of failure in the iTerm2 branch, fixed there with per-item `try`
- #124 — same user-visible symptom, different root cause (`tty` local variable shadowing)

The iTerm2 branches (lines 588, 617, 653) still enumerate tabs unguarded. They
have an outer `try`, so a bad window can't break the app — it just silently ends
the search. Happy to fold that into this PR if you'd prefer one sweep.