### PR TITLE
fix(cursor): fold merge/hide Tasks via safe _ppid parent fallback

### DIFF
--- a/Sources/CodeIsland/AppState+TranscriptTailer.swift
+++ b/Sources/CodeIsland/AppState+TranscriptTailer.swift
@@ -22,7 +22,13 @@ extension AppState {
         attachedTranscriptPaths[sessionId] = path
 
         // Backfill messages from the transcript file so recentMessages is populated
-        let (_, messages) = Self.readRecentFromTranscript(path: path)
+        let messages: [ChatMessage]
+        if let source = sessions[sessionId]?.source,
+           source == "cursor" || source == "cursor-cli" {
+            messages = Self.readRecentFromCursorTranscript(path: path).1
+        } else {
+            messages = Self.readRecentFromTranscript(path: path).1
+        }
         if !messages.isEmpty, var session = sessions[sessionId] {
             session.recentMessages = messages
             if let lastUser = messages.last(where: { $0.isUser }) {

--- a/Sources/CodeIsland/AppState+TranscriptTailer.swift
+++ b/Sources/CodeIsland/AppState+TranscriptTailer.swift
@@ -227,19 +227,39 @@ extension AppState {
             mutated = true
         }
 
-        if let prompt = delta.lastUserPrompt, session.lastUserPrompt != prompt {
-            session.lastUserPrompt = prompt
-            if session.recentMessages.last(where: { $0.isUser })?.text != prompt {
-                session.addRecentMessage(ChatMessage(isUser: true, text: prompt))
+        if let prompt = delta.lastUserPrompt {
+            let normalizedIncoming = JSONLTailer.normalizedCursorChatText(from: prompt) ?? prompt
+            let normalizedCurrent = session.lastUserPrompt.flatMap {
+                JSONLTailer.normalizedCursorChatText(from: $0) ?? $0
             }
-            mutated = true
+            if normalizedCurrent != normalizedIncoming {
+                session.lastUserPrompt = normalizedIncoming
+                let lastUserText = session.recentMessages.last(where: { $0.isUser })?.text
+                let lastNormalized = lastUserText.flatMap {
+                    JSONLTailer.normalizedCursorChatText(from: $0) ?? $0
+                }
+                if lastNormalized != normalizedIncoming {
+                    session.addRecentMessage(ChatMessage(isUser: true, text: normalizedIncoming))
+                }
+                mutated = true
+            }
         }
-        if let reply = delta.lastAssistantMessage, session.lastAssistantMessage != reply {
-            session.lastAssistantMessage = reply
-            if session.recentMessages.last(where: { !$0.isUser })?.text != reply {
-                session.addRecentMessage(ChatMessage(isUser: false, text: reply))
+        if let reply = delta.lastAssistantMessage {
+            let normalizedIncoming = JSONLTailer.normalizedCursorChatText(from: reply) ?? reply
+            let normalizedCurrent = session.lastAssistantMessage.flatMap {
+                JSONLTailer.normalizedCursorChatText(from: $0) ?? $0
             }
-            mutated = true
+            if normalizedCurrent != normalizedIncoming {
+                session.lastAssistantMessage = normalizedIncoming
+                let lastAssistantText = session.recentMessages.last(where: { !$0.isUser })?.text
+                let lastNormalized = lastAssistantText.flatMap {
+                    JSONLTailer.normalizedCursorChatText(from: $0) ?? $0
+                }
+                if lastNormalized != normalizedIncoming {
+                    session.addRecentMessage(ChatMessage(isUser: false, text: normalizedIncoming))
+                }
+                mutated = true
+            }
         }
 
         // Cursor question tool has no hook channel (#265) — the transcript tail is

--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -5435,7 +5435,7 @@ final class AppState {
         return nil
     }
 
-    private nonisolated static func readRecentFromCursorTranscript(path: String) -> (String?, [ChatMessage]) {
+    nonisolated static func readRecentFromCursorTranscript(path: String) -> (String?, [ChatMessage]) {
         guard let handle = FileHandle(forReadingAtPath: path) else { return (nil, []) }
         defer { handle.closeFile() }
 
@@ -5454,7 +5454,8 @@ final class AppState {
                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
                   let role = json["role"] as? String,
                   let message = json["message"] as? [String: Any],
-                  let textContent = extractTextContent(from: message["content"])
+                  let textContent = JSONLTailer.normalizedCursorChatText(from: message["content"])
+                    ?? extractTextContent(from: message["content"])
             else { continue }
 
             if role == "user" {

--- a/Sources/CodeIsland/AppState.swift
+++ b/Sources/CodeIsland/AppState.swift
@@ -1166,6 +1166,16 @@ final class AppState {
 
         let effects = reduceEvent(sessions: &sessions, event: event, maxHistory: maxHistory)
 
+        // Cursor Agent Tasks often fire Claude-format hooks without `--source`,
+        // leaving ghost Claude cards. Rebrand + fold before the rest of the
+        // pipeline treats them as standalone Claude sessions.
+        if sessions.contains(where: {
+            let source = SessionSnapshot.normalizedSupportedSource($0.value.source)
+            return source == nil || source == "claude"
+        }) {
+            _ = applyCursorSubsessionModeToKnownSessions()
+        }
+
         // After reduce: remoteHostId is authoritative (extractMetadata just ran),
         // so a remote session can never probe the local filesystem here.
         maybeRefreshGitBranch(for: sessionId, cwdBefore: cwdBeforeReduce, normalizedEventName: normalizedEventName)
@@ -2967,8 +2977,12 @@ final class AppState {
             return false
         }
 
+        // Cursor Agent Tasks that fired Claude-format hooks keep default
+        // source=claude and never enter the fold loop — rebrand first.
+        var didMutate = rebrandMisattributedCursorTaskCards()
+
+        // Refresh after rebrand so newly tagged cursor cards are included.
         let candidates = sessions.map { (sessionId: $0.key, session: $0.value) }
-        var didMutate = false
 
         if mode == "hide" {
             for candidate in candidates {
@@ -3217,6 +3231,91 @@ final class AppState {
         }
         if let parentFromCard {
             return (parentFromCard, candidate.sessionId)
+        }
+        return nil
+    }
+
+    /// Rebrand default-Claude cards that are actually Cursor Agent Tasks
+    /// (`~/.cursor/.../agent-transcripts/.../subagents/<id>.jsonl`).
+    @discardableResult
+    func rebrandMisattributedCursorTaskCards() -> Bool {
+        var didMutate = false
+        for (sessionId, snap) in sessions {
+            let normalized = SessionSnapshot.normalizedSupportedSource(snap.source)
+            guard normalized == nil || normalized == "claude" else { continue }
+
+            if let path = snap.transcriptPath,
+               CursorSessionFolding.isCursorAgentTranscriptPath(path) {
+                sessions[sessionId]?.source = "cursor"
+                didMutate = true
+                continue
+            }
+
+            guard let found = Self.findCursorSubagentTranscriptPath(
+                sessionId: sessionId,
+                cwd: snap.cwd
+            ) else {
+                continue
+            }
+            sessions[sessionId]?.source = "cursor"
+            if sessions[sessionId]?.transcriptPath == nil {
+                sessions[sessionId]?.transcriptPath = found
+            }
+            didMutate = true
+        }
+        return didMutate
+    }
+
+    /// Locate `…/agent-transcripts/<parent>/subagents/<sessionId>.jsonl` under
+    /// `~/.cursor/projects`. Prefers the cwd-encoded project when available.
+    nonisolated static func findCursorSubagentTranscriptPath(
+        sessionId: String,
+        cwd: String?,
+        home: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        fm: FileManager = .default
+    ) -> String? {
+        let trimmed = sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let projectsRoot = "\(home)/.cursor/projects"
+
+        var searchRoots: [String] = []
+        if let cwd, !cwd.isEmpty {
+            searchRoots.append("\(projectsRoot)/\(cwd.appProjectDirEncoded())/agent-transcripts")
+        }
+        // Prefer cwd project; fall back to scanning other Cursor projects.
+        var found: String?
+        for base in searchRoots {
+            if let path = Self.firstSubagentTranscript(in: base, sessionId: trimmed, fm: fm) {
+                found = path
+                break
+            }
+        }
+        if found == nil {
+            if let projects = try? fm.contentsOfDirectory(atPath: projectsRoot) {
+                for project in projects {
+                    let base = "\(projectsRoot)/\(project)/agent-transcripts"
+                    if searchRoots.contains(base) { continue }
+                    if let path = Self.firstSubagentTranscript(in: base, sessionId: trimmed, fm: fm) {
+                        found = path
+                        break
+                    }
+                }
+            }
+        }
+        return found
+    }
+
+    private nonisolated static func firstSubagentTranscript(
+        in transcriptBase: String,
+        sessionId: String,
+        fm: FileManager
+    ) -> String? {
+        let suffix = "/subagents/\(sessionId).jsonl"
+        guard let enumerator = fm.enumerator(atPath: transcriptBase) else { return nil }
+        while let rel = enumerator.nextObject() as? String {
+            if rel.hasSuffix(suffix) || rel == String(suffix.dropFirst()) {
+                return "\(transcriptBase)/\(rel)"
+            }
         }
         return nil
     }

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -467,8 +467,15 @@ class HookServer {
     ) -> (processedData: Data, responseData: Data?)? {
         guard mode == "hide" || mode == "merge",
               CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: raw),
-              let parentId = cursorSubsessionParentId(from: raw),
               let childId = Self.rawSessionId(from: raw) else {
+            return nil
+        }
+        // Established top-level card for this session_id = main chat continuing.
+        // Never `_ppid`-fold it onto a sibling Task (that freezes parent chat text).
+        if cursorSessionCardExists(for: childId) {
+            return nil
+        }
+        guard let parentId = cursorSubsessionParentId(from: raw) else {
             return nil
         }
         if mode == "hide" {
@@ -480,6 +487,21 @@ class HookServer {
             parentSessionId: parentId,
             childSessionId: childId
         )
+    }
+
+    /// True when `sessionId` already names a top-level AppState Cursor card
+    /// (exact key or `providerSessionId` match).
+    private func cursorSessionCardExists(for sessionId: String) -> Bool {
+        if let snap = appState.sessions[sessionId],
+           CursorSubsessionRouter.isCursorFamilySource(snap.source) {
+            return true
+        }
+        if let key = appState.findSessionId(providerSessionId: sessionId),
+           let snap = appState.sessions[key],
+           CursorSubsessionRouter.isCursorFamilySource(snap.source) {
+            return true
+        }
+        return false
     }
 
     /// Test seam for Agent Sub-Sessions pre-routing (Cursor / Codex / plugin).

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -262,20 +262,17 @@ class HookServer {
     }
 
     private static func pluginPpid(from raw: [String: Any]) -> Int? {
-        if let p = raw["_ppid"] as? Int { return p }
-        if let p = raw["_ppid"] as? Int32 { return Int(p) }
-        if let p = raw["_ppid"] as? NSNumber { return p.intValue }
-        return nil
+        CursorSubsessionRouter.positivePpid(from: raw)
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {
         guard let string = value as? String else { return nil }
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : string
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private static func rawSessionId(from raw: [String: Any]) -> String? {
-        nonEmptyString(raw["session_id"]) ?? nonEmptyString(raw["sessionId"])
+        CursorSubsessionRouter.sessionId(from: raw)
     }
 
     private static func rawEventName(from raw: [String: Any]) -> String? {
@@ -315,6 +312,7 @@ class HookServer {
     private static let cursorTranscriptMarkerBytes = Data("agent-transcripts".utf8)
     private static let cursorSourceExactBytes = Data(#""_source":"cursor""#.utf8)
     private static let cursorCliSourceExactBytes = Data(#""_source":"cursor-cli""#.utf8)
+    private static let ppidKeyBytes = Data(#""_ppid""#.utf8)
     /// JSON `\uXXXX` escape — only then do we fall back to a full parse.
     private static let jsonUnicodeEscapeBytes = Data(#"\u"#.utf8)
     private static let cursorSourceFlexibleRegex: NSRegularExpression = {
@@ -324,7 +322,7 @@ class HookServer {
         )
     }()
 
-    /// Whether Cursor Task routing may need a JSON parse.
+    /// Whether Cursor Task routing may need a JSON parse (transcript fold path).
     ///
     /// Requires `agent-transcripts` plus `_source` of `cursor` / `cursor-cli`
     /// (not bare "cursor" elsewhere). Fast path: compact bridge literals, then
@@ -333,12 +331,17 @@ class HookServer {
     /// text merely mentions `agent-transcripts` do not pay for a parse.
     internal static func mayNeedCursorSubsessionRouting(data: Data) -> Bool {
         guard data.range(of: cursorTranscriptMarkerBytes) != nil else { return false }
+        return mayBeCursorHookSource(data: data)
+    }
+
+    /// `_source` is `cursor` / `cursor-cli` (compact, spaced, or `\u`-escaped).
+    /// Used for merge/hide `_ppid` fallback when `agent-transcripts` is absent.
+    internal static func mayBeCursorHookSource(data: Data) -> Bool {
         // Compact forms first — bridge JSONSerialization emits no spaces after `:`.
         if data.range(of: cursorCliSourceExactBytes) != nil
             || data.range(of: cursorSourceExactBytes) != nil {
             return true
         }
-        // No `_source` key → cannot be a Cursor hook source field.
         guard data.range(of: sourceMarkerBytes) != nil else { return false }
         if let text = String(data: data, encoding: .utf8) {
             let range = NSRange(text.startIndex..., in: text)
@@ -346,13 +349,12 @@ class HookServer {
                 return true
             }
         }
-        // Literal/regex miss with unicode escapes in the payload (e.g. `\u0063ursor`).
         guard data.range(of: jsonUnicodeEscapeBytes) != nil,
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let source = obj["_source"] as? String else {
             return false
         }
-        return source == "cursor" || source == "cursor-cli"
+        return CursorSubsessionRouter.isCursorFamilySource(source)
     }
 
     private static func codexSubagentMetadata(from raw: [String: Any]) -> CodexSubagentMetadata? {
@@ -387,21 +389,128 @@ class HookServer {
         )
     }
 
+    /// Resolve parent via `_ppid` after transcript fold failed. Only call when
+    /// ``CursorSubsessionRouter.shouldAttemptPpidParentFallback`` is true.
+    ///
+    /// Requires a **unique** active same-PID Cursor card for the preferred source
+    /// (then sibling). If two chats share the IDE process, guessing is unsafe —
+    /// leave the Task separate until `transcript_path` can fold it.
+    private func cursorSubsessionParentId(from raw: [String: Any]) -> String? {
+        guard let source = SessionSnapshot.normalizedSupportedSource(raw["_source"] as? String),
+              CursorSubsessionRouter.isCursorFamilySource(source),
+              let childSessionId = Self.rawSessionId(from: raw),
+              let ppid = Self.pluginPpid(from: raw) else {
+            return nil
+        }
+        let cutoff = Date().addingTimeInterval(-300)
+        for src in CursorSubsessionRouter.parentSourceSearchOrder(primarySource: source) {
+            if let match = uniqueActiveSamePidCursorSession(
+                source: src,
+                ppid: ppid,
+                excluding: childSessionId,
+                activeSince: cutoff
+            ) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    /// Sole non-idle same-PID session for `source`, or `nil` when zero / ambiguous.
+    private func uniqueActiveSamePidCursorSession(
+        source: String,
+        ppid: Int,
+        excluding excludedSessionId: String,
+        activeSince cutoff: Date
+    ) -> String? {
+        let normalized = SessionSnapshot.normalizedSupportedSource(source)
+        let matches = appState.sessions.compactMap { sessionId, snap -> String? in
+            let snapSource = SessionSnapshot.normalizedSupportedSource(snap.source)
+            guard snapSource == normalized,
+                  snap.cliPid == pid_t(ppid),
+                  snap.lastActivity >= cutoff,
+                  sessionId != excludedSessionId,
+                  snap.status != .idle else {
+                return nil
+            }
+            return sessionId
+        }
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
+
+    /// Rewrite `raw` onto the parent session and serialize.
+    /// On serialization failure, returns the original hook `data` unchanged.
+    private func applyCursorMerge(
+        data: Data,
+        raw: [String: Any],
+        parentSessionId: String,
+        childSessionId: String
+    ) -> (processedData: Data, responseData: Data?) {
+        var rewritten = raw
+        CursorSubsessionRouter.applyMerge(
+            to: &rewritten,
+            parentSessionId: parentSessionId,
+            childSessionId: childSessionId
+        )
+        guard let newData = try? JSONSerialization.data(withJSONObject: rewritten) else {
+            return (data, nil)
+        }
+        return (newData, nil)
+    }
+
+    /// merge/hide fallback when transcript fold returned `.leave`.
+    private func routeCursorLeaveFallback(
+        data: Data,
+        raw: [String: Any],
+        mode: String
+    ) -> (processedData: Data, responseData: Data?)? {
+        guard mode == "hide" || mode == "merge",
+              CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: raw),
+              let parentId = cursorSubsessionParentId(from: raw),
+              let childId = Self.rawSessionId(from: raw) else {
+            return nil
+        }
+        if mode == "hide" {
+            return (data, Self.hiddenPluginResponse(for: raw))
+        }
+        return applyCursorMerge(
+            data: data,
+            raw: raw,
+            parentSessionId: parentId,
+            childSessionId: childId
+        )
+    }
+
+    /// Test seam for Agent Sub-Sessions pre-routing (Cursor / Codex / plugin).
+    internal func routeSubsessionPayloadIfNeededForTesting(
+        data: Data
+    ) -> (processedData: Data, responseData: Data?) {
+        routeSubsessionPayloadIfNeeded(data: data)
+    }
+
     private func routeSubsessionPayloadIfNeeded(data: Data) -> (processedData: Data, responseData: Data?) {
         let mayNeedPluginOrCodex = data.range(of: Self.pluginMarkerBytes) != nil
             || (data.range(of: Self.sourceMarkerBytes) != nil && data.range(of: Self.codexMarkerBytes) != nil)
-        let mayNeedCursor = Self.mayNeedCursorSubsessionRouting(data: data)
+        let mayNeedCursorTranscript = Self.mayNeedCursorSubsessionRouting(data: data)
 
         let mode = UserDefaults.standard.string(forKey: SettingsKey.pluginSessionMode)
             ?? SettingsDefaults.pluginSessionMode
+        let isMergeOrHide = mode == "hide" || mode == "merge"
+
+        // merge/hide: parse Cursor hooks that lack `agent-transcripts` only when
+        // `_ppid` is present — otherwise there is nothing for the fallback to use.
+        let mayNeedCursorPpidFallback = isMergeOrHide
+            && Self.mayBeCursorHookSource(data: data)
+            && data.range(of: Self.ppidKeyBytes) != nil
 
         // Cursor Task routing is a no-op in separate mode; skip JSON parse when
         // the payload is Cursor-only (Codex/plugin may still need it below).
-        if mayNeedCursor && !mayNeedPluginOrCodex && mode != "hide" && mode != "merge" {
+        if mayNeedCursorTranscript && !mayNeedPluginOrCodex && !isMergeOrHide {
             return (data, nil)
         }
 
-        guard mayNeedPluginOrCodex || mayNeedCursor,
+        guard mayNeedPluginOrCodex || mayNeedCursorTranscript || mayNeedCursorPpidFallback,
               let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return (data, nil)
         }
@@ -409,23 +518,24 @@ class HookServer {
         // Cursor Task/subagent: apply Agent Sub-Sessions (separate / merge / hide).
         switch CursorSubsessionRouter.decide(raw: raw, mode: mode) {
         case .leave:
-            break
+            if let routed = routeCursorLeaveFallback(data: data, raw: raw, mode: mode) {
+                return routed
+            }
         case .hide:
             return (data, Self.hiddenPluginResponse(for: raw))
         case .merge(let parentSessionId, let childSessionId):
-            var rewritten = raw
-            CursorSubsessionRouter.applyMerge(
-                to: &rewritten,
-                parentSessionId: parentSessionId,
+            // Transcript parent UUID may differ from the AppState session key.
+            let resolvedParent = appState.findSessionId(providerSessionId: parentSessionId)
+                ?? parentSessionId
+            return applyCursorMerge(
+                data: data,
+                raw: raw,
+                parentSessionId: resolvedParent,
                 childSessionId: childSessionId
             )
-            if let newData = try? JSONSerialization.data(withJSONObject: rewritten) {
-                return (newData, nil)
-            }
-            return (data, nil)
         }
 
-        guard mode == "hide" || mode == "merge" else {
+        guard isMergeOrHide else {
             return (data, nil)
         }
 

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -324,14 +324,12 @@ class HookServer {
 
     /// Whether Cursor Task routing may need a JSON parse (transcript fold path).
     ///
-    /// Requires `agent-transcripts` plus `_source` of `cursor` / `cursor-cli`
-    /// (not bare "cursor" elsewhere). Fast path: compact bridge literals, then
-    /// whitespace-tolerant regex (only if `"_source"` is present). JSON fallback
-    /// runs only when a `\u` escape is also present — so non-cursor hooks whose
-    /// text merely mentions `agent-transcripts` do not pay for a parse.
+    /// Requires `agent-transcripts` plus either a Cursor `_source` or a path under
+    /// `/.cursor/` (misbranded Claude-default Task hooks still fold).
     internal static func mayNeedCursorSubsessionRouting(data: Data) -> Bool {
         guard data.range(of: cursorTranscriptMarkerBytes) != nil else { return false }
-        return mayBeCursorHookSource(data: data)
+        if mayBeCursorHookSource(data: data) { return true }
+        return data.range(of: Data("/.cursor/".utf8)) != nil
     }
 
     /// `_source` is `cursor` / `cursor-cli` (compact, spaced, or `\u`-escaped).

--- a/Sources/CodeIsland/HookServer.swift
+++ b/Sources/CodeIsland/HookServer.swift
@@ -416,7 +416,8 @@ class HookServer {
         return nil
     }
 
-    /// Sole non-idle same-PID session for `source`, or `nil` when zero / ambiguous.
+    /// Sole suitable same-PID session for `source`, or `nil` when zero / ambiguous.
+    /// Prefers main chats over orphan Task cards; idle mains remain eligible.
     private func uniqueActiveSamePidCursorSession(
         source: String,
         ppid: Int,
@@ -424,19 +425,33 @@ class HookServer {
         activeSince cutoff: Date
     ) -> String? {
         let normalized = SessionSnapshot.normalizedSupportedSource(source)
-        let matches = appState.sessions.compactMap { sessionId, snap -> String? in
-            let snapSource = SessionSnapshot.normalizedSupportedSource(snap.source)
-            guard snapSource == normalized,
-                  snap.cliPid == pid_t(ppid),
-                  snap.lastActivity >= cutoff,
-                  sessionId != excludedSessionId,
-                  snap.status != .idle else {
-                return nil
+        let candidates: [(sessionId: String, status: AgentStatus, startTime: Date, isMain: Bool, isTask: Bool)] =
+            appState.sessions.compactMap { sessionId, snap in
+                let snapSource = SessionSnapshot.normalizedSupportedSource(snap.source)
+                guard snapSource == normalized,
+                      snap.cliPid == pid_t(ppid),
+                      sessionId != excludedSessionId else {
+                    return nil
+                }
+                // Recent activity, or idle with live IDE pid (main often idles while
+                // a Task keeps the process busy).
+                guard snap.lastActivity >= cutoff || snap.status == .idle else {
+                    return nil
+                }
+                let isTask = CursorSubsessionRouter.isLikelyCursorTaskCard(
+                    sessionId: sessionId,
+                    providerSessionId: snap.providerSessionId,
+                    transcriptPath: snap.transcriptPath
+                )
+                let isMain = CursorSubsessionRouter.isLikelyCursorMainCard(
+                    sessionId: sessionId,
+                    providerSessionId: snap.providerSessionId,
+                    transcriptPath: snap.transcriptPath,
+                    hasSubagents: !snap.subagents.isEmpty
+                )
+                return (sessionId, snap.status, snap.startTime, isMain, isTask)
             }
-            return sessionId
-        }
-        guard matches.count == 1 else { return nil }
-        return matches[0]
+        return CursorSubsessionRouter.choosePpidFallbackParentId(candidates: candidates)
     }
 
     /// Rewrite `raw` onto the parent session and serialize.

--- a/Sources/CodeIsland/MascotView.swift
+++ b/Sources/CodeIsland/MascotView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CodeIslandCore
 
 // MARK: - Mascot Animation Speed Environment
 
@@ -22,8 +23,9 @@ struct MascotView: View {
     @ObservedObject private var animationGate = MascotAnimationGate.shared
 
     var body: some View {
+        let resolved = SessionSnapshot.normalizedSupportedSource(source) ?? source
         Group {
-            switch source {
+            switch resolved {
             case "codex":
                 DexView(status: status, size: size)
             case "gemini", "google-antigravity":

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -2719,10 +2719,7 @@ private struct TerminalBadge: View {
     }
 
     private var badgeLabel: String? {
-        if session.isCLIHostedInForeignApp {
-            return session.sourceLabel
-        }
-        return session.terminalName
+        session.terminalBadgeLabel
     }
 
     private let remoteColor = Color(red: 0.3, green: 0.75, blue: 0.5)

--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -447,7 +447,14 @@ private struct CompactLeftWing: View {
         // happening. Covers no-session and all-idle equally (#149) — without
         // this, an idle session's source overrides the user preference.
         if displayStatus == .idle { return settingsDefaultSource }
-        if let s = displaySession?.source { return s }
+        // Prefer mascotSource so a Cursor/Codex session with empty hook source
+        // still resolves via termBundleId instead of falling through to Clawd.
+        if let s = displaySession {
+            let resolved = s.mascotSource
+            if !resolved.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return resolved
+            }
+        }
         return appState.primarySource
     }
     private var displayStatus: AgentStatus { displaySession?.status ?? .idle }
@@ -2204,7 +2211,7 @@ private struct SessionCard: View {
         HStack(alignment: .center, spacing: 8) {
             // Column 1: Character + subagent icons
             VStack(spacing: 3) {
-                MascotView(source: session.source, status: session.status, size: 32)
+                MascotView(source: session.mascotSource, status: session.status, size: 32)
                 if showAgentDetails && !session.subagents.isEmpty {
                     let sorted = session.subagents.values.sorted { $0.startTime < $1.startTime }
                     // Grid: 4 per row, 8px icons
@@ -2696,13 +2703,26 @@ private struct TerminalBadge: View {
     private static var termIconCache: [String: NSImage] = [:]
 
     private var termIcon: NSImage? {
-        let bid = session.termBundleId ?? Self.sourceBundleIds[session.source]
+        // CLI hosted in a foreign IDE: show the agent icon, not the host IDE.
+        if session.isCLIHostedInForeignApp,
+           let src = SessionSnapshot.normalizedSupportedSource(session.source),
+           let icon = cliIcon(source: src, size: 13) {
+            return icon
+        }
+        let bid = session.termBundleId ?? Self.sourceBundleIds[session.mascotSource]
         guard let bid else { return nil }
         if let cached = Self.termIconCache[bid] { return cached }
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bid) else { return nil }
         let icon = NSWorkspace.shared.icon(forFile: url.path)
         Self.termIconCache[bid] = icon
         return icon
+    }
+
+    private var badgeLabel: String? {
+        if session.isCLIHostedInForeignApp {
+            return session.sourceLabel
+        }
+        return session.terminalName
     }
 
     private let remoteColor = Color(red: 0.3, green: 0.75, blue: 0.5)
@@ -2733,7 +2753,7 @@ private struct TerminalBadge: View {
                             .resizable()
                             .frame(width: 13, height: 13)
                     }
-                    if let term = session.terminalName {
+                    if let term = badgeLabel {
                         Text(term)
                             .font(.system(size: 9.5, weight: .medium, design: .monospaced))
                             .foregroundStyle(.white.opacity(0.5))

--- a/Sources/CodeIslandCore/CursorSessionFolding.swift
+++ b/Sources/CodeIslandCore/CursorSessionFolding.swift
@@ -53,23 +53,44 @@ public enum CursorSubsessionRouteDecision: Equatable {
 }
 
 public enum CursorSubsessionRouter {
+    /// `cursor` / `cursor-cli` after normalization.
+    public static func isCursorFamilySource(_ source: String?) -> Bool {
+        let normalized = SessionSnapshot.normalizedSupportedSource(source)
+        return normalized == "cursor" || normalized == "cursor-cli"
+    }
+
+    /// Positive process id from `_ppid` (Int / Int32 / NSNumber / decimal String).
+    public static func positivePpid(from raw: [String: Any]) -> Int? {
+        let parsed: Int?
+        if let p = raw["_ppid"] as? Int {
+            parsed = p
+        } else if let p = raw["_ppid"] as? Int32 {
+            parsed = Int(p)
+        } else if let p = raw["_ppid"] as? NSNumber {
+            parsed = p.intValue
+        } else if let s = raw["_ppid"] as? String {
+            parsed = Int(s.trimmingCharacters(in: .whitespacesAndNewlines))
+        } else {
+            parsed = nil
+        }
+        guard let parsed, parsed > 0 else { return nil }
+        return parsed
+    }
+
     /// Apply Agent Sub-Sessions (`separate` / `merge` / `hide`) to Cursor hooks.
     /// Same three modes as Codex and plugin children.
     public static func decide(raw: [String: Any], mode: String) -> CursorSubsessionRouteDecision {
-        let normalizedSource = SessionSnapshot.normalizedSupportedSource(
+        guard isCursorFamilySource(
             (raw["_source"] as? String) ?? (raw["source"] as? String)
-        )
-        guard normalizedSource == "cursor" || normalizedSource == "cursor-cli" else {
+        ) else {
             return .leave
         }
 
-        let childSessionId = nonEmptyString(raw["session_id"]) ?? nonEmptyString(raw["sessionId"])
-        guard let childSessionId else { return .leave }
+        guard let childSessionId = sessionId(from: raw) else { return .leave }
 
-        let transcriptPath = nonEmptyString(raw["transcript_path"]) ?? nonEmptyString(raw["transcriptPath"])
         guard let parentId = CursorSessionFolding.foldTarget(
             childSessionId: childSessionId,
-            transcriptPath: transcriptPath
+            transcriptPath: transcriptPath(from: raw)
         ) else {
             return .leave
         }
@@ -97,6 +118,39 @@ public enum CursorSubsessionRouter {
             raw["agent_type"] = "cursor-subagent"
         }
         raw["_cursor_subagent"] = true
+    }
+
+    /// Whether merge/hide may resolve a parent via `_ppid` after transcript fold
+    /// returned `.leave`.
+    ///
+    /// True only with Cursor source + session id + positive `_ppid` and **no**
+    /// parseable parent UUID in `transcript_path`. A parseable parent means either
+    /// the main chat or a foldable Task (`decide` already handles the latter).
+    public static func shouldAttemptPpidParentFallback(raw: [String: Any]) -> Bool {
+        guard isCursorFamilySource((raw["_source"] as? String) ?? (raw["source"] as? String)),
+              sessionId(from: raw) != nil,
+              positivePpid(from: raw) != nil else {
+            return false
+        }
+        if let path = transcriptPath(from: raw),
+           CursorSessionFolding.parentConversationId(fromTranscriptPath: path) != nil {
+            return false
+        }
+        return true
+    }
+
+    /// Search order for same-IDE parent lookup: event source first, then sibling.
+    public static func parentSourceSearchOrder(primarySource: String) -> [String] {
+        let normalized = SessionSnapshot.normalizedSupportedSource(primarySource) ?? primarySource
+        return normalized == "cursor-cli" ? ["cursor-cli", "cursor"] : ["cursor", "cursor-cli"]
+    }
+
+    public static func sessionId(from raw: [String: Any]) -> String? {
+        nonEmptyString(raw["session_id"]) ?? nonEmptyString(raw["sessionId"])
+    }
+
+    public static func transcriptPath(from raw: [String: Any]) -> String? {
+        nonEmptyString(raw["transcript_path"]) ?? nonEmptyString(raw["transcriptPath"])
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {

--- a/Sources/CodeIslandCore/CursorSessionFolding.swift
+++ b/Sources/CodeIslandCore/CursorSessionFolding.swift
@@ -145,6 +145,95 @@ public enum CursorSubsessionRouter {
         return normalized == "cursor-cli" ? ["cursor-cli", "cursor"] : ["cursor", "cursor-cli"]
     }
 
+    /// True when this top-level card is a foldable Cursor Task (transcript parent ≠ id).
+    public static func isLikelyCursorTaskCard(
+        sessionId: String,
+        providerSessionId: String?,
+        transcriptPath: String?
+    ) -> Bool {
+        if CursorSessionFolding.foldTarget(
+            childSessionId: sessionId,
+            transcriptPath: transcriptPath
+        ) != nil {
+            return true
+        }
+        if let providerSessionId,
+           providerSessionId != sessionId,
+           CursorSessionFolding.foldTarget(
+               childSessionId: providerSessionId,
+               transcriptPath: transcriptPath
+           ) != nil {
+            return true
+        }
+        return false
+    }
+
+    /// True when the card looks like a main Cursor chat (owns its transcript dir,
+    /// or already parents live/folded Tasks).
+    public static func isLikelyCursorMainCard(
+        sessionId: String,
+        providerSessionId: String?,
+        transcriptPath: String?,
+        hasSubagents: Bool
+    ) -> Bool {
+        if hasSubagents { return true }
+        let identities = [sessionId, providerSessionId].compactMap { id -> String? in
+            guard let id else { return nil }
+            let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        guard let path = transcriptPath,
+              let parentId = CursorSessionFolding.parentConversationId(fromTranscriptPath: path)
+        else {
+            return false
+        }
+        return identities.contains(parentId)
+    }
+
+    /// Pick a unique `_ppid` parent among same-PID Cursor cards.
+    ///
+    /// - Excludes foldable Task cards (never parent onto an orphan Task).
+    /// - Prefers main-looking cards (self transcript / already has subagents).
+    /// - Allows a unique idle main when it shares the IDE pid (main often goes
+    ///   idle while a Task is still running).
+    /// - 2+ live non-Task chats → ambiguous (`nil`).
+    public static func choosePpidFallbackParentId(
+        candidates: [(sessionId: String, status: AgentStatus, startTime: Date, isMain: Bool, isTask: Bool)]
+    ) -> String? {
+        let eligible = candidates.filter { !$0.isTask }
+        guard !eligible.isEmpty else { return nil }
+
+        let mains = eligible.filter(\.isMain)
+        let pool = mains.isEmpty ? eligible : mains
+        if pool.count == 1 { return pool[0].sessionId }
+
+        let active = pool.filter { $0.status != .idle }
+        let idle = pool.filter { $0.status == .idle }
+
+        // Two+ live chats on the same IDE process — do not guess.
+        if active.count >= 2 { return nil }
+        if active.count == 1 {
+            // Idle leftovers + one live card: prefer unique main among idle+active,
+            // else the older idle card when it predates the live orphan Task.
+            if idle.isEmpty { return active[0].sessionId }
+            if let mainIdle = idle.first(where: \.isMain), idle.filter(\.isMain).count == 1 {
+                return mainIdle.sessionId
+            }
+            if let oldestIdle = idle.min(by: { $0.startTime < $1.startTime }),
+               oldestIdle.startTime < active[0].startTime {
+                return oldestIdle.sessionId
+            }
+            return active[0].sessionId
+        }
+
+        // All idle: unique oldest only when startTimes differ.
+        let sorted = pool.sorted { $0.startTime < $1.startTime }
+        guard sorted.count >= 2, sorted[0].startTime < sorted[1].startTime else {
+            return nil
+        }
+        return sorted[0].sessionId
+    }
+
     public static func sessionId(from raw: [String: Any]) -> String? {
         nonEmptyString(raw["session_id"]) ?? nonEmptyString(raw["sessionId"])
     }

--- a/Sources/CodeIslandCore/CursorSessionFolding.swift
+++ b/Sources/CodeIslandCore/CursorSessionFolding.swift
@@ -9,6 +9,17 @@ public enum CursorSessionFolding {
     /// UUID segment under `agent-transcripts/`.
     private static let uuidDirPattern = #"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"#
 
+    /// True when `path` is under Cursor's `agent-transcripts` tree
+    /// (`~/.cursor/projects/…/agent-transcripts/…`).
+    public static func isCursorAgentTranscriptPath(_ path: String?) -> Bool {
+        guard let path = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return false
+        }
+        guard path.contains("/agent-transcripts/") else { return false }
+        return path.contains("/.cursor/") || path.contains("/cursor/projects/")
+    }
+
     /// Parent conversation id from a Cursor `transcript_path`, when present.
     ///
     /// Recognized layouts:
@@ -59,6 +70,21 @@ public enum CursorSubsessionRouter {
         return normalized == "cursor" || normalized == "cursor-cli"
     }
 
+    /// Treat as Cursor Task routing even when `_source` is missing or still the
+    /// default `"claude"` — Cursor Agent Tasks often fire Claude-format hooks
+    /// without `--source`, which would otherwise leave a ghost Claude card.
+    public static func shouldTreatAsCursorFamily(
+        declaredSource: String?,
+        transcriptPath: String?
+    ) -> Bool {
+        if isCursorFamilySource(declaredSource) { return true }
+        guard CursorSessionFolding.isCursorAgentTranscriptPath(transcriptPath) else {
+            return false
+        }
+        let normalized = SessionSnapshot.normalizedSupportedSource(declaredSource)
+        return normalized == nil || normalized == "claude"
+    }
+
     /// Positive process id from `_ppid` (Int / Int32 / NSNumber / decimal String).
     public static func positivePpid(from raw: [String: Any]) -> Int? {
         let parsed: Int?
@@ -80,9 +106,9 @@ public enum CursorSubsessionRouter {
     /// Apply Agent Sub-Sessions (`separate` / `merge` / `hide`) to Cursor hooks.
     /// Same three modes as Codex and plugin children.
     public static func decide(raw: [String: Any], mode: String) -> CursorSubsessionRouteDecision {
-        guard isCursorFamilySource(
-            (raw["_source"] as? String) ?? (raw["source"] as? String)
-        ) else {
+        let declared = (raw["_source"] as? String) ?? (raw["source"] as? String)
+        let path = transcriptPath(from: raw)
+        guard shouldTreatAsCursorFamily(declaredSource: declared, transcriptPath: path) else {
             return .leave
         }
 
@@ -90,7 +116,7 @@ public enum CursorSubsessionRouter {
 
         guard let parentId = CursorSessionFolding.foldTarget(
             childSessionId: childSessionId,
-            transcriptPath: transcriptPath(from: raw)
+            transcriptPath: path
         ) else {
             return .leave
         }
@@ -118,21 +144,27 @@ public enum CursorSubsessionRouter {
             raw["agent_type"] = "cursor-subagent"
         }
         raw["_cursor_subagent"] = true
+        // Misbranded Claude-default Task hooks must land as Cursor on the parent.
+        if !isCursorFamilySource((raw["_source"] as? String) ?? (raw["source"] as? String)) {
+            raw["_source"] = "cursor"
+        }
     }
 
     /// Whether merge/hide may resolve a parent via `_ppid` after transcript fold
     /// returned `.leave`.
     ///
-    /// True only with Cursor source + session id + positive `_ppid` and **no**
-    /// parseable parent UUID in `transcript_path`. A parseable parent means either
-    /// the main chat or a foldable Task (`decide` already handles the latter).
+    /// True with Cursor family (including misbranded Claude-default + Cursor
+    /// transcript path) + session id + positive `_ppid` and **no** parseable
+    /// parent UUID in `transcript_path`.
     public static func shouldAttemptPpidParentFallback(raw: [String: Any]) -> Bool {
-        guard isCursorFamilySource((raw["_source"] as? String) ?? (raw["source"] as? String)),
+        let declared = (raw["_source"] as? String) ?? (raw["source"] as? String)
+        let path = transcriptPath(from: raw)
+        guard shouldTreatAsCursorFamily(declaredSource: declared, transcriptPath: path),
               sessionId(from: raw) != nil,
               positivePpid(from: raw) != nil else {
             return false
         }
-        if let path = transcriptPath(from: raw),
+        if let path,
            CursorSessionFolding.parentConversationId(fromTranscriptPath: path) != nil {
             return false
         }

--- a/Sources/CodeIslandCore/JSONLTailer.swift
+++ b/Sources/CodeIslandCore/JSONLTailer.swift
@@ -375,16 +375,9 @@ public final class JSONLTailer: @unchecked Sendable {
 
     /// Handle one Cursor `role`-keyed transcript entry.
     ///
-    /// Only the trailing-question state is derived here: an assistant entry
-    /// carrying an unanswered AskQuestion tool call marks the question pending,
-    /// and any other user/assistant entry supersedes it — last writer wins, so
-    /// only the newest entry in a scan determines the state.
-    ///
-    /// Chat text is deliberately NOT extracted from this shape: Cursor hooks
-    /// (`beforeSubmitPrompt` / `afterAgentResponse`) already stream the same
-    /// messages, and the transcript copies differ cosmetically (`<user_query>`
-    /// wrappers, redaction markers), so a second source would produce
-    /// near-duplicate chat rows.
+    /// Updates trailing-question state and normalized chat text. Chat text is
+    /// stripped of `<timestamp>` / `<user_query>` wrappers so it can refresh the
+    /// island when hooks miss or are folded as subagent events (#merge staleness).
     private static func applyCursorRoleLine(
         role: String,
         message: [String: Any],
@@ -393,15 +386,36 @@ public final class JSONLTailer: @unchecked Sendable {
         switch role {
         case "user":
             delta.cursorQuestion = .cleared
+            if let text = normalizedCursorChatText(from: message["content"]) {
+                delta.lastUserPrompt = text
+            }
         case "assistant":
             if let prompt = cursorQuestionPrompt(inContent: message["content"]) {
                 delta.cursorQuestion = .pending(prompt: prompt)
             } else {
                 delta.cursorQuestion = .cleared
             }
+            if let text = normalizedCursorChatText(from: message["content"]) {
+                delta.lastAssistantMessage = text
+            }
         default:
             break
         }
+    }
+
+    /// Strip Cursor transcript wrappers so hook and transcript copies can dedupe.
+    public static func normalizedCursorChatText(from content: Any?) -> String? {
+        guard var text = extractText(from: content) else { return nil }
+        while let start = text.range(of: "<timestamp>"),
+              let end = text.range(of: "</timestamp>", range: start.upperBound..<text.endIndex) {
+            text.removeSubrange(start.lowerBound..<end.upperBound)
+        }
+        if let start = text.range(of: "<user_query>"),
+           let end = text.range(of: "</user_query>", range: start.upperBound..<text.endIndex) {
+            text = String(text[start.upperBound..<end.lowerBound])
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// Extract the question text when a Cursor assistant `content` array carries a

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -1573,6 +1573,20 @@ private func handleSubagentEvent(
         }
         sessions[sessionId]?.subagents[agentId]?.status = .processing
         sessions[sessionId]?.subagents[agentId]?.lastActivity = Date()
+        // Merge-into-main: keep parent chat text live for folded Cursor Tasks
+        // (and for main-chat hooks that were incorrectly tagged with agent_id).
+        let prompt = firstStringFromEvent(
+            event,
+            keys: ["prompt", "user_prompt", "userPrompt", "message", "input", "content", "text"],
+            includeNested: true
+        )
+        if let prompt {
+            sessions[sessionId]?.lastUserPrompt = prompt
+            if sessions[sessionId]?.recentMessages.last?.isUser == true {
+                sessions[sessionId]?.recentMessages.removeLast()
+            }
+            sessions[sessionId]?.addRecentMessage(ChatMessage(isUser: true, text: prompt))
+        }
         if sessions[sessionId]?.status != .waitingApproval && sessions[sessionId]?.status != .waitingQuestion {
             let agentType = sessions[sessionId]?.subagents[agentId]?.agentType
             sessions[sessionId]?.status = .running
@@ -1645,9 +1659,19 @@ private func handleSubagentEvent(
 
     case "AfterAgentResponse":
         // Merged Cursor Task events arrive with parent session_id + child agent_id.
-        // Handle here so they do not overwrite the parent's reply or enqueue a false completion.
         guard ensureSubagent(sessions: &sessions, sessionId: sessionId, agentId: agentId, event: event) else {
             return true
+        }
+        // Surface the folded reply on the parent card (merge-into-main), but never
+        // enqueue parent-turn completion from a Task response.
+        let responseText = firstStringFromEvent(
+            event,
+            keys: ["text", "message"],
+            includeNested: true
+        )
+        if let text = responseText, !text.isEmpty {
+            sessions[sessionId]?.lastAssistantMessage = text
+            sessions[sessionId]?.addRecentMessage(ChatMessage(isUser: false, text: text))
         }
         sessions[sessionId]?.subagents[agentId]?.status = .processing
         sessions[sessionId]?.subagents[agentId]?.lastActivity = Date()

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -1325,6 +1325,18 @@ private func shouldReopenCursorSubagentOnPrompt(event: HookEvent, session: Sessi
     return source == "cursor" || source == "cursor-cli"
 }
 
+/// Whether folded-child prompt/response text should appear on the parent card.
+private func shouldSurfaceCursorSubagentChat(event: HookEvent, session: SessionSnapshot?) -> Bool {
+    if (event.rawJSON["_cursor_subagent"] as? Bool) == true {
+        return true
+    }
+    return CursorSubsessionRouter.isCursorFamilySource(
+        (event.rawJSON["_source"] as? String)
+            ?? (event.rawJSON["source"] as? String)
+            ?? session?.source
+    )
+}
+
 public func extractMetadata(into sessions: inout [String: SessionSnapshot], sessionId: String, event: HookEvent) {
     let eventCwd = event.rawJSON["cwd"] as? String
     if let cwd = eventCwd, !cwd.isEmpty,
@@ -1573,14 +1585,15 @@ private func handleSubagentEvent(
         }
         sessions[sessionId]?.subagents[agentId]?.status = .processing
         sessions[sessionId]?.subagents[agentId]?.lastActivity = Date()
-        // Merge-into-main: keep parent chat text live for folded Cursor Tasks
-        // (and for main-chat hooks that were incorrectly tagged with agent_id).
-        let prompt = firstStringFromEvent(
-            event,
-            keys: ["prompt", "user_prompt", "userPrompt", "message", "input", "content", "text"],
-            includeNested: true
-        )
-        if let prompt {
+        // Cursor merge-into-main only: keep parent chat text live for folded Tasks
+        // (and for main-chat hooks incorrectly tagged with agent_id). Do not apply
+        // to Codex/plugin children — their prompts must not overwrite the parent card.
+        if shouldSurfaceCursorSubagentChat(event: event, session: sessions[sessionId]),
+           let prompt = firstStringFromEvent(
+               event,
+               keys: ["prompt", "user_prompt", "userPrompt"],
+               includeNested: true
+           ) {
             sessions[sessionId]?.lastUserPrompt = prompt
             if sessions[sessionId]?.recentMessages.last?.isUser == true {
                 sessions[sessionId]?.recentMessages.removeLast()
@@ -1662,14 +1675,15 @@ private func handleSubagentEvent(
         guard ensureSubagent(sessions: &sessions, sessionId: sessionId, agentId: agentId, event: event) else {
             return true
         }
-        // Surface the folded reply on the parent card (merge-into-main), but never
+        // Cursor-only: surface the folded reply on the parent card, but never
         // enqueue parent-turn completion from a Task response.
-        let responseText = firstStringFromEvent(
-            event,
-            keys: ["text", "message"],
-            includeNested: true
-        )
-        if let text = responseText, !text.isEmpty {
+        if shouldSurfaceCursorSubagentChat(event: event, session: sessions[sessionId]),
+           let text = firstStringFromEvent(
+               event,
+               keys: ["text", "message"],
+               includeNested: true
+           ),
+           !text.isEmpty {
             sessions[sessionId]?.lastAssistantMessage = text
             sessions[sessionId]?.addRecentMessage(ChatMessage(isUser: false, text: text))
         }

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -680,6 +680,39 @@ public struct SessionSnapshot: Sendable {
         "com.anthropic.claudefordesktop": "claude",
     ]
 
+    /// Source id for the native app that owns `bundleId`, if any.
+    public static func sourceForAppBundleId(_ bundleId: String) -> String? {
+        appBundleSources[bundleId]
+    }
+
+    /// Source used for the session-card mascot.
+    ///
+    /// Prefers the hook/discovery source. When that is missing, fall back to the
+    /// native-app bundle map so a Cursor/Codex desktop session does not render
+    /// as the default Claude mascot while the right-hand badge still says Cursor.
+    public var mascotSource: String {
+        if let normalized = Self.normalizedSupportedSource(source) {
+            return normalized
+        }
+        if let bid = termBundleId, let inferred = Self.appBundleSources[bid] {
+            return inferred
+        }
+        return source
+    }
+
+    /// True when this is a CLI agent hosted inside another IDE/app terminal
+    /// (e.g. Claude Code inside Cursor) — mascot/badge should follow the CLI,
+    /// not the host IDE brand.
+    public var isCLIHostedInForeignApp: Bool {
+        guard isIDETerminal,
+              let src = Self.normalizedSupportedSource(source),
+              let bid = termBundleId,
+              let hostSource = Self.appBundleSources[bid] else {
+            return false
+        }
+        return src != hostSource
+    }
+
     /// Short terminal/app name for display tag
     public var terminalName: String? {
         if isRemote {

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -1326,6 +1326,13 @@ public func fillMissingParentMetadataFromSubagentEvent(
        source != "claude" {
         sessions[sessionId]?.source = source
     }
+    // Cursor Task hooks often omit `--source` and keep the default "claude".
+    // Rebrand when transcript_path is clearly under Cursor agent-transcripts.
+    if sessions[sessionId]?.source == "claude",
+       let path = event.rawJSON["transcript_path"] as? String,
+       CursorSessionFolding.isCursorAgentTranscriptPath(path) {
+        sessions[sessionId]?.source = "cursor"
+    }
 
     let cwdMissing = sessions[sessionId]?.cwd == nil
         || SessionSnapshot.isUnhelpfulHookCwd(sessions[sessionId]?.cwd ?? "")
@@ -1462,6 +1469,13 @@ public func extractMetadata(into sessions: inout [String: SessionSnapshot], sess
     }
     if let source = SessionSnapshot.normalizedSupportedSource(event.rawJSON["_source"] as? String) {
         sessions[sessionId]?.source = source
+    } else if sessions[sessionId]?.source == "claude",
+              let path = (event.rawJSON["transcript_path"] as? String)
+                ?? (event.rawJSON["transcriptPath"] as? String),
+              CursorSessionFolding.isCursorAgentTranscriptPath(path) {
+        // Untagged Cursor Agent Task hooks inherit SessionSnapshot's default
+        // "claude" — rebrand so merge/hide and the badge follow Cursor.
+        sessions[sessionId]?.source = "cursor"
     }
     // cmux surface / workspace (injected by bridge from CMUX_SURFACE_ID / CMUX_WORKSPACE_ID env vars)
     if let surface = event.rawJSON["_cmux_surface_id"] as? String, !surface.isEmpty {

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -713,6 +713,15 @@ public struct SessionSnapshot: Sendable {
         return src != hostSource
     }
 
+    /// Right-hand session badge text: CLI brand when hosted in a foreign IDE,
+    /// otherwise the host terminal/app name.
+    public var terminalBadgeLabel: String? {
+        if isCLIHostedInForeignApp {
+            return sourceLabel
+        }
+        return terminalName
+    }
+
     /// Short terminal/app name for display tag
     public var terminalName: String? {
         if isRemote {

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -93,13 +93,20 @@ final class CursorSessionFoldingTests: XCTestCase {
         XCTAssertEqual(CursorSubsessionRouter.decide(raw: raw, mode: "merge"), .leave)
     }
 
-    func testRouterLeavesNonCursorSources() {
+    func testRouterLeavesNonCursorSourcesWithoutCursorTranscript() {
         let raw: [String: Any] = [
-            "_source": "claude",
+            "_source": "codex",
             "session_id": "2528cb91-6379-48f2-aff8-40f4b804dafa",
-            "transcript_path": "/Users/u/.cursor/projects/x/agent-transcripts/e1247fd5-d9a0-48ef-8457-0304606b1833/e1247fd5-d9a0-48ef-8457-0304606b1833.jsonl",
+            "transcript_path": "/Users/u/.cursor/projects/x/agent-transcripts/e1247fd5-d9a0-48ef-8457-0304606b1833/subagents/2528cb91-6379-48f2-aff8-40f4b804dafa.jsonl",
         ]
         XCTAssertEqual(CursorSubsessionRouter.decide(raw: raw, mode: "merge"), .leave)
+
+        let claudeElsewhere: [String: Any] = [
+            "_source": "claude",
+            "session_id": "2528cb91-6379-48f2-aff8-40f4b804dafa",
+            "transcript_path": "/Users/u/.claude/projects/-tmp/2528cb91-6379-48f2-aff8-40f4b804dafa.jsonl",
+        ]
+        XCTAssertEqual(CursorSubsessionRouter.decide(raw: claudeElsewhere, mode: "merge"), .leave)
     }
 
     func testShouldAttemptPpidFallbackOnlyWithoutParseableTranscriptParent() {
@@ -260,6 +267,46 @@ final class CursorSessionFoldingTests: XCTestCase {
                 sessionId: parentId,
                 providerSessionId: parentId,
                 transcriptPath: mainPath
+            )
+        )
+    }
+
+    func testRouterMergesMisbrandedClaudeDefaultCursorTask() {
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+        let path = "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/subagents/\(childId).jsonl"
+        let raw: [String: Any] = [
+            "_source": "claude",
+            "session_id": childId,
+            "transcript_path": path,
+        ]
+        XCTAssertEqual(
+            CursorSubsessionRouter.decide(raw: raw, mode: "merge"),
+            .merge(parentSessionId: parentId, childSessionId: childId)
+        )
+        var rewritten = raw
+        CursorSubsessionRouter.applyMerge(
+            to: &rewritten,
+            parentSessionId: parentId,
+            childSessionId: childId
+        )
+        XCTAssertEqual(rewritten["_source"] as? String, "cursor")
+        XCTAssertEqual(rewritten["_cursor_subagent"] as? Bool, true)
+    }
+
+    func testShouldTreatAsCursorFamilyForMisbrandedClaudePath() {
+        let path = "/Users/u/.cursor/projects/x/agent-transcripts/p/subagents/c.jsonl"
+        XCTAssertTrue(
+            CursorSubsessionRouter.shouldTreatAsCursorFamily(
+                declaredSource: "claude",
+                transcriptPath: path
+            )
+        )
+        XCTAssertTrue(CursorSessionFolding.isCursorAgentTranscriptPath(path))
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldTreatAsCursorFamily(
+                declaredSource: "claude",
+                transcriptPath: nil
             )
         )
     }

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -226,39 +226,68 @@ final class CursorSessionFoldingTests: XCTestCase {
         XCTAssertNil(raw["_cursor_subagent_event"])
     }
 
-    func testMergedCursorSubagentAfterAgentResponseDoesNotCompleteParent() throws {
+    func testMergedCursorSubagentAfterAgentResponseUpdatesParentChatWithoutCompleting() throws {
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
         var parent = SessionSnapshot()
         parent.source = "cursor"
         parent.status = .running
         parent.lastUserPrompt = "main prompt"
         parent.lastAssistantMessage = "parent reply"
+        parent.subagents[childId] = SubagentState(agentId: childId, agentType: "cursor-subagent")
 
-        var sessions = ["e1247fd5-d9a0-48ef-8457-0304606b1833": parent]
+        var sessions = [parentId: parent]
         let data = try JSONSerialization.data(withJSONObject: [
             "hook_event_name": "afterAgentResponse",
-            "session_id": "e1247fd5-d9a0-48ef-8457-0304606b1833",
+            "session_id": parentId,
             "_source": "cursor",
-            "agent_id": "2528cb91-6379-48f2-aff8-40f4b804dafa",
+            "agent_id": childId,
             "agent_type": "cursor-subagent",
             "text": "child-only reply",
         ] as [String: Any])
         let event = try XCTUnwrap(HookEvent(from: data))
         let effects = reduceEvent(sessions: &sessions, event: event, maxHistory: 10)
 
-        XCTAssertEqual(
-            sessions["e1247fd5-d9a0-48ef-8457-0304606b1833"]?.lastAssistantMessage,
-            "parent reply"
-        )
-        XCTAssertEqual(sessions["e1247fd5-d9a0-48ef-8457-0304606b1833"]?.status, .running)
+        // Merge-into-main: surface the folded reply on the parent card…
+        XCTAssertEqual(sessions[parentId]?.lastAssistantMessage, "child-only reply")
+        XCTAssertEqual(sessions[parentId]?.recentMessages.last?.text, "child-only reply")
+        XCTAssertEqual(sessions[parentId]?.recentMessages.last?.isUser, false)
+        // …but never treat a Task response as parent-turn completion.
+        XCTAssertEqual(sessions[parentId]?.status, .running)
         XCTAssertFalse(effects.contains(where: {
             if case .enqueueCompletion = $0 { return true }
             return false
         }))
-        XCTAssertEqual(
-            sessions["e1247fd5-d9a0-48ef-8457-0304606b1833"]?
-                .subagents["2528cb91-6379-48f2-aff8-40f4b804dafa"]?.status,
-            .processing
-        )
+        XCTAssertEqual(sessions[parentId]?.subagents[childId]?.status, .processing)
+    }
+
+    func testMergedCursorUserPromptSubmitUpdatesParentChat() throws {
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+        var parent = SessionSnapshot()
+        parent.source = "cursor"
+        parent.status = .running
+        parent.lastUserPrompt = "old prompt"
+        parent.addRecentMessage(ChatMessage(isUser: true, text: "old prompt"))
+        parent.subagents[childId] = SubagentState(agentId: childId, agentType: "cursor-subagent")
+        var sessions = [parentId: parent]
+
+        let data = try JSONSerialization.data(withJSONObject: [
+            "hook_event_name": "beforeSubmitPrompt",
+            "session_id": parentId,
+            "_source": "cursor",
+            "agent_id": childId,
+            "_cursor_subagent": true,
+            "prompt": "continue after the root cause",
+        ] as [String: Any])
+        let event = try XCTUnwrap(HookEvent(from: data))
+        _ = reduceEvent(sessions: &sessions, event: event, maxHistory: 10)
+
+        XCTAssertEqual(sessions[parentId]?.lastUserPrompt, "continue after the root cause")
+        XCTAssertEqual(sessions[parentId]?.recentMessages.last?.text, "continue after the root cause")
+        XCTAssertEqual(sessions[parentId]?.recentMessages.last?.isUser, true)
+        XCTAssertEqual(sessions[parentId]?.status, .running)
+        XCTAssertEqual(sessions[parentId]?.currentTool, "Agent")
     }
 
     func testSubagentStopRecordsClosedTombstoneAndClearsOnRestart() throws {

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -102,6 +102,112 @@ final class CursorSessionFoldingTests: XCTestCase {
         XCTAssertEqual(CursorSubsessionRouter.decide(raw: raw, mode: "merge"), .leave)
     }
 
+    func testShouldAttemptPpidFallbackOnlyWithoutParseableTranscriptParent() {
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+        let mainPath = "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/\(parentId).jsonl"
+
+        // Main chat: parent UUID parsed == session_id → never ppid-fallback.
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": parentId,
+                "transcript_path": mainPath,
+            ])
+        )
+
+        // Foldable Task path: parent UUID parses → decide handles merge; no ppid.
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+                "transcript_path": mainPath,
+            ])
+        )
+
+        // No transcript_path → ppid fallback allowed.
+        XCTAssertTrue(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": 42,
+            ])
+        )
+
+        // Unparseable path (no agent-transcripts UUID) → ppid fallback allowed.
+        XCTAssertTrue(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+                "transcript_path": "/tmp/other.jsonl",
+                "_ppid": 42,
+            ])
+        )
+
+        // Missing _ppid → no fallback.
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+            ])
+        )
+
+        // Invalid / zero ppid → no fallback.
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": 0,
+            ])
+        )
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": -1,
+            ])
+        )
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": "nope",
+            ])
+        )
+
+        // String / camelCase sessionId + positive ppid still qualify.
+        XCTAssertTrue(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor-cli",
+                "sessionId": childId,
+                "_ppid": "7",
+            ])
+        )
+        XCTAssertTrue(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor-cli",
+                "sessionId": childId,
+                "_ppid": NSNumber(value: 7),
+            ])
+        )
+
+        // Missing session id → no fallback.
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "cursor",
+                "_ppid": 42,
+            ])
+        )
+
+        XCTAssertFalse(
+            CursorSubsessionRouter.shouldAttemptPpidParentFallback(raw: [
+                "_source": "claude",
+                "session_id": childId,
+                "_ppid": 42,
+            ])
+        )
+    }
+
     func testApplyMergeRewritesSessionAndSetsAgentId() {
         var raw: [String: Any] = [
             "session_id": "2528cb91-6379-48f2-aff8-40f4b804dafa",

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -372,6 +372,37 @@ final class CursorSessionFoldingTests: XCTestCase {
         XCTAssertEqual(sessions[parentId]?.subagents[childId]?.status, .processing)
     }
 
+    func testCodexSubagentAfterAgentResponseDoesNotOverwriteParentChat() throws {
+        let parentId = "thread-parent"
+        let childId = "thread-child"
+        var parent = SessionSnapshot()
+        parent.source = "codex"
+        parent.status = .running
+        parent.lastAssistantMessage = "parent reply"
+        parent.addRecentMessage(ChatMessage(isUser: false, text: "parent reply"))
+        parent.subagents[childId] = SubagentState(agentId: childId, agentType: "worker")
+        var sessions = [parentId: parent]
+
+        let data = try JSONSerialization.data(withJSONObject: [
+            "hook_event_name": "AfterAgentResponse",
+            "session_id": parentId,
+            "_source": "codex",
+            "agent_id": childId,
+            "text": "child-only reply must not replace parent",
+        ] as [String: Any])
+        let event = try XCTUnwrap(HookEvent(from: data))
+        let effects = reduceEvent(sessions: &sessions, event: event, maxHistory: 10)
+
+        XCTAssertEqual(sessions[parentId]?.lastAssistantMessage, "parent reply")
+        XCTAssertEqual(sessions[parentId]?.recentMessages.filter { !$0.isUser }.count, 1)
+        XCTAssertEqual(sessions[parentId]?.recentMessages.last?.text, "parent reply")
+        XCTAssertFalse(effects.contains(where: {
+            if case .enqueueCompletion = $0 { return true }
+            return false
+        }))
+        XCTAssertEqual(sessions[parentId]?.subagents[childId]?.status, .processing)
+    }
+
     func testSubagentStopRecordsClosedTombstoneAndClearsOnRestart() throws {
         let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
         let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -208,6 +208,62 @@ final class CursorSessionFoldingTests: XCTestCase {
         )
     }
 
+    func testChoosePpidFallbackParentPrefersMainOverRunningTask() {
+        let older = Date().addingTimeInterval(-600)
+        let newer = Date().addingTimeInterval(-30)
+        let chosen = CursorSubsessionRouter.choosePpidFallbackParentId(candidates: [
+            (sessionId: "main", status: .idle, startTime: older, isMain: true, isTask: false),
+            (sessionId: "task", status: .running, startTime: newer, isMain: false, isTask: false),
+        ])
+        XCTAssertEqual(chosen, "main")
+    }
+
+    func testChoosePpidFallbackParentExcludesTaskCards() {
+        let chosen = CursorSubsessionRouter.choosePpidFallbackParentId(candidates: [
+            (sessionId: "main", status: .idle, startTime: Date().addingTimeInterval(-600), isMain: false, isTask: false),
+            (sessionId: "task", status: .running, startTime: Date(), isMain: false, isTask: true),
+        ])
+        XCTAssertEqual(chosen, "main")
+    }
+
+    func testChoosePpidFallbackParentRejectsTwoLiveChats() {
+        let chosen = CursorSubsessionRouter.choosePpidFallbackParentId(candidates: [
+            (sessionId: "a", status: .running, startTime: Date().addingTimeInterval(-100), isMain: false, isTask: false),
+            (sessionId: "b", status: .running, startTime: Date(), isMain: false, isTask: false),
+        ])
+        XCTAssertNil(chosen)
+    }
+
+    func testIsLikelyCursorMainAndTaskCardFromTranscript() {
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+        let mainPath = "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/\(parentId).jsonl"
+        let taskPath = "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/subagents/\(childId).jsonl"
+
+        XCTAssertTrue(
+            CursorSubsessionRouter.isLikelyCursorMainCard(
+                sessionId: parentId,
+                providerSessionId: parentId,
+                transcriptPath: mainPath,
+                hasSubagents: false
+            )
+        )
+        XCTAssertTrue(
+            CursorSubsessionRouter.isLikelyCursorTaskCard(
+                sessionId: childId,
+                providerSessionId: nil,
+                transcriptPath: taskPath
+            )
+        )
+        XCTAssertFalse(
+            CursorSubsessionRouter.isLikelyCursorTaskCard(
+                sessionId: parentId,
+                providerSessionId: parentId,
+                transcriptPath: mainPath
+            )
+        )
+    }
+
     func testApplyMergeRewritesSessionAndSetsAgentId() {
         var raw: [String: Any] = [
             "session_id": "2528cb91-6379-48f2-aff8-40f4b804dafa",

--- a/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
+++ b/Tests/CodeIslandCoreTests/CursorSessionFoldingTests.swift
@@ -290,6 +290,32 @@ final class CursorSessionFoldingTests: XCTestCase {
         XCTAssertEqual(sessions[parentId]?.currentTool, "Agent")
     }
 
+    func testCodexSubagentUserPromptSubmitDoesNotOverwriteParentChat() throws {
+        let parentId = "thread-parent"
+        let childId = "thread-child"
+        var parent = SessionSnapshot()
+        parent.source = "codex"
+        parent.status = .running
+        parent.lastUserPrompt = "parent prompt"
+        parent.addRecentMessage(ChatMessage(isUser: true, text: "parent prompt"))
+        parent.subagents[childId] = SubagentState(agentId: childId, agentType: "worker")
+        var sessions = [parentId: parent]
+
+        let data = try JSONSerialization.data(withJSONObject: [
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": parentId,
+            "_source": "codex",
+            "agent_id": childId,
+            "prompt": "child-only prompt must not replace parent",
+        ] as [String: Any])
+        let event = try XCTUnwrap(HookEvent(from: data))
+        _ = reduceEvent(sessions: &sessions, event: event, maxHistory: 10)
+
+        XCTAssertEqual(sessions[parentId]?.lastUserPrompt, "parent prompt")
+        XCTAssertEqual(sessions[parentId]?.recentMessages.last?.text, "parent prompt")
+        XCTAssertEqual(sessions[parentId]?.subagents[childId]?.status, .processing)
+    }
+
     func testSubagentStopRecordsClosedTombstoneAndClearsOnRestart() throws {
         let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
         let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"

--- a/Tests/CodeIslandCoreTests/JSONLTailerCursorQuestionTests.swift
+++ b/Tests/CodeIslandCoreTests/JSONLTailerCursorQuestionTests.swift
@@ -36,20 +36,26 @@ final class JSONLTailerCursorQuestionTests: XCTestCase {
         JSONLTailer.scanLines(Data((lines.joined(separator: "\n") + "\n").utf8))
     }
 
-    // MARK: - Role-keyed lines produce only question signals
+    // MARK: - Role-keyed lines: question signals + normalized chat text
 
-    func testCursorUserLineClearsQuestionWithoutDuplicatingChatText() {
-        // Chat text stays hook-sourced (beforeSubmitPrompt) — the transcript copy
-        // is wrapped in <user_query> tags and would dedup-miss into a second row.
+    func testCursorUserLineClearsQuestionAndExtractsChatText() {
         let result = scan([cursorUserLine(text: "fix the bug")])
-        XCTAssertNil(result.delta.lastUserPrompt)
+        XCTAssertEqual(result.delta.lastUserPrompt, "fix the bug")
         XCTAssertNil(result.delta.lastAssistantMessage)
         XCTAssertEqual(result.delta.cursorQuestion, .cleared)
     }
 
-    func testCursorAssistantTextLineClearsQuestionWithoutDuplicatingChatText() {
+    func testCursorAssistantTextLineClearsQuestionAndExtractsChatText() {
         let result = scan([cursorAssistantTextLine(text: "done, deployed")])
-        XCTAssertNil(result.delta.lastAssistantMessage)
+        XCTAssertEqual(result.delta.lastAssistantMessage, "done, deployed")
+        XCTAssertEqual(result.delta.cursorQuestion, .cleared)
+    }
+
+    func testCursorUserLineStripsTimestampAndUserQueryWrappers() {
+        // Keep `role` as the first key (Cursor writer / quickTypeProbe).
+        let line = #"{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Thursday, Jul 30, 2026, 3:51 PM (UTC+8)</timestamp>\n<user_query>\n## 根因分析\n</user_query>"}]}}"#
+        let result = scan([line])
+        XCTAssertEqual(result.delta.lastUserPrompt, "## 根因分析")
         XCTAssertEqual(result.delta.cursorQuestion, .cleared)
     }
 
@@ -60,7 +66,8 @@ final class JSONLTailerCursorQuestionTests: XCTestCase {
         let result = scan([cursorQuestionLine(inputJSON: input, leadingText: "I need one detail.")])
 
         XCTAssertEqual(result.delta.cursorQuestion, .pending(prompt: "Which database should we target?"))
-        XCTAssertNil(result.delta.lastAssistantMessage)
+        // Leading assistant prose before AskQuestion still refreshes chat text.
+        XCTAssertEqual(result.delta.lastAssistantMessage, "I need one detail.")
     }
 
     func testAskQuestionMultiplePromptsGetNumericSuffix() {

--- a/Tests/CodeIslandTests/AppStateCursorQuestionTests.swift
+++ b/Tests/CodeIslandTests/AppStateCursorQuestionTests.swift
@@ -223,6 +223,64 @@ final class AppStateCursorQuestionTests: XCTestCase {
         XCTAssertEqual(appState.sessions[mainId]?.lastUserPrompt, "PostgreSQL")
     }
 
+    // MARK: - Cursor chat dedupe (hook plain text vs transcript wrappers)
+
+    func testTranscriptDeltaDoesNotDuplicateHookPromptWrappedInUserQuery() {
+        let path = mainTranscriptPath(for: mainId)
+        let appState = AppState()
+        var session = cursorSession(status: .processing, transcriptPath: path)
+        session.lastUserPrompt = "investigate the crash"
+        session.addRecentMessage(ChatMessage(isUser: true, text: "investigate the crash"))
+        appState.sessions[mainId] = session
+
+        appState.applyTranscriptDelta(ConversationTailDelta(
+            sessionId: mainId,
+            lastUserPrompt: "<timestamp>2026-07-30</timestamp>\n<user_query>\ninvestigate the crash\n</user_query>",
+            lastAssistantMessage: nil
+        ))
+
+        XCTAssertEqual(appState.sessions[mainId]?.lastUserPrompt, "investigate the crash")
+        XCTAssertEqual(appState.sessions[mainId]?.recentMessages.filter(\.isUser).count, 1)
+        XCTAssertEqual(appState.sessions[mainId]?.recentMessages.last(where: \.isUser)?.text, "investigate the crash")
+    }
+
+    func testTranscriptDeltaDoesNotDuplicateHookAssistantReplyWithTimestampWrapper() {
+        let path = mainTranscriptPath(for: mainId)
+        let appState = AppState()
+        var session = cursorSession(status: .processing, transcriptPath: path)
+        session.lastAssistantMessage = "here is the fix"
+        session.addRecentMessage(ChatMessage(isUser: false, text: "here is the fix"))
+        appState.sessions[mainId] = session
+
+        appState.applyTranscriptDelta(ConversationTailDelta(
+            sessionId: mainId,
+            lastUserPrompt: nil,
+            lastAssistantMessage: "<timestamp>t</timestamp>here is the fix"
+        ))
+
+        XCTAssertEqual(appState.sessions[mainId]?.lastAssistantMessage, "here is the fix")
+        XCTAssertEqual(appState.sessions[mainId]?.recentMessages.filter { !$0.isUser }.count, 1)
+    }
+
+    func testTranscriptDeltaAppendsWhenNormalizedChatTextDiffers() {
+        let path = mainTranscriptPath(for: mainId)
+        let appState = AppState()
+        var session = cursorSession(status: .processing, transcriptPath: path)
+        session.lastUserPrompt = "first question"
+        session.addRecentMessage(ChatMessage(isUser: true, text: "first question"))
+        appState.sessions[mainId] = session
+
+        appState.applyTranscriptDelta(ConversationTailDelta(
+            sessionId: mainId,
+            lastUserPrompt: "<user_query>second question</user_query>",
+            lastAssistantMessage: nil
+        ))
+
+        XCTAssertEqual(appState.sessions[mainId]?.lastUserPrompt, "second question")
+        XCTAssertEqual(appState.sessions[mainId]?.recentMessages.filter(\.isUser).count, 2)
+        XCTAssertEqual(appState.sessions[mainId]?.recentMessages.last(where: \.isUser)?.text, "second question")
+    }
+
     // MARK: - Hook activity resumes the display wait
 
     func testHookActivityAfterDisplayWaitResumesProcessing() throws {

--- a/Tests/CodeIslandTests/AppStateCursorSubsessionTests.swift
+++ b/Tests/CodeIslandTests/AppStateCursorSubsessionTests.swift
@@ -43,6 +43,68 @@ final class AppStateCursorSubsessionTests: XCTestCase {
         XCTAssertEqual(appState.activeSessionId, parentId)
     }
 
+    func testMisbrandedClaudeDefaultCursorTaskRebrandsAndMerges() {
+        let previousMode = UserDefaults.standard.object(forKey: SettingsKey.pluginSessionMode)
+        UserDefaults.standard.set("merge", forKey: SettingsKey.pluginSessionMode)
+        defer {
+            if let previousMode {
+                UserDefaults.standard.set(previousMode, forKey: SettingsKey.pluginSessionMode)
+            } else {
+                UserDefaults.standard.removeObject(forKey: SettingsKey.pluginSessionMode)
+            }
+        }
+
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+        let transcriptPath =
+            "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/subagents/\(childId).jsonl"
+
+        let appState = AppState()
+        var parent = SessionSnapshot()
+        parent.source = "cursor"
+        parent.status = .running
+        parent.providerSessionId = parentId
+        parent.transcriptPath =
+            "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/\(parentId).jsonl"
+
+        // Ghost card: default Claude source, Cursor host, Task transcript on disk path.
+        var child = SessionSnapshot()
+        child.source = "claude"
+        child.status = .running
+        child.termBundleId = "com.todesktop.230313mzl4w4u92"
+        child.transcriptPath = transcriptPath
+        child.lastActivity = Date()
+
+        appState.sessions[parentId] = parent
+        appState.sessions[childId] = child
+
+        XCTAssertTrue(appState.applyCursorSubsessionModeToKnownSessions())
+        XCTAssertNil(appState.sessions[childId], "ghost Claude Task card should fold away")
+        XCTAssertEqual(appState.sessions[parentId]?.subagents[childId]?.agentType, "cursor-subagent")
+        XCTAssertEqual(appState.sessions[parentId]?.source, "cursor")
+    }
+
+    func testFindCursorSubagentTranscriptPathLocatesFileUnderProject() throws {
+        let home = NSTemporaryDirectory() + "cursor-subagent-find-" + UUID().uuidString
+        let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+        let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+        let cwd = "/Users/zephyr/Code/CodeIsland"
+        let project = cwd.appProjectDirEncoded()
+        let dir = "\(home)/.cursor/projects/\(project)/agent-transcripts/\(parentId)/subagents"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let path = "\(dir)/\(childId).jsonl"
+        try " {}\n".write(toFile: path, atomically: true, encoding: .utf8)
+
+        let found = AppState.findCursorSubagentTranscriptPath(
+            sessionId: childId,
+            cwd: cwd,
+            home: home
+        )
+        XCTAssertEqual(found, path)
+    }
+
     func testSeparateModeSplitsMergedCursorSubagent() {
         let previousMode = UserDefaults.standard.object(forKey: SettingsKey.pluginSessionMode)
         UserDefaults.standard.set("separate", forKey: SettingsKey.pluginSessionMode)

--- a/Tests/CodeIslandTests/HookServerCursorPpidFallbackTests.swift
+++ b/Tests/CodeIslandTests/HookServerCursorPpidFallbackTests.swift
@@ -1,0 +1,440 @@
+import XCTest
+@testable import CodeIsland
+import CodeIslandCore
+
+/// Coverage for merge/hide `_ppid` parent fallback when Cursor Task hooks omit
+/// a foldable `transcript_path` (safe path: never ppid-fold a parseable main chat).
+@MainActor
+final class HookServerCursorPpidFallbackTests: XCTestCase {
+    private let parentId = "e1247fd5-d9a0-48ef-8457-0304606b1833"
+    private let childId = "2528cb91-6379-48f2-aff8-40f4b804dafa"
+    private let otherId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    private func withPluginSessionMode(_ mode: String, _ body: () throws -> Void) rethrows {
+        let previous = UserDefaults.standard.object(forKey: SettingsKey.pluginSessionMode)
+        UserDefaults.standard.set(mode, forKey: SettingsKey.pluginSessionMode)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: SettingsKey.pluginSessionMode)
+            } else {
+                UserDefaults.standard.removeObject(forKey: SettingsKey.pluginSessionMode)
+            }
+        }
+        try body()
+    }
+
+    private func makeRunningCursorSession(
+        source: String = "cursor",
+        cliPid: Int,
+        lastActivity: Date = Date(),
+        startTime: Date = Date(),
+        providerSessionId: String? = nil
+    ) -> SessionSnapshot {
+        var snap = SessionSnapshot(startTime: startTime)
+        snap.source = source
+        snap.status = .running
+        snap.cliPid = pid_t(cliPid)
+        snap.lastActivity = lastActivity
+        snap.providerSessionId = providerSessionId
+        return snap
+    }
+
+    private func route(
+        appState: AppState,
+        payload: [String: Any]
+    ) throws -> (processedData: Data, responseData: Data?, raw: [String: Any]) {
+        let server = HookServer(appState: appState)
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let routed = server.routeSubsessionPayloadIfNeededForTesting(data: data)
+        let raw = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: routed.processedData) as? [String: Any]
+        )
+        return (routed.processedData, routed.responseData, raw)
+    }
+
+    // MARK: - Happy paths
+
+    func testMergeModePpidFallbackRewritesChildOntoActiveParent() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_001
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Read",
+            ])
+            XCTAssertNil(routed.responseData)
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
+            XCTAssertEqual(routed.raw["agent_type"] as? String, "cursor-subagent")
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
+    func testMergeModePpidFallbackAcceptsCamelCaseSessionIdAndNSNumberPpid() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_002
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "sessionId": childId,
+                "_ppid": NSNumber(value: ppid),
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
+        }
+    }
+
+    func testMergeModePpidFallbackWithUnparseableTranscriptPath() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_003
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "transcript_path": "/tmp/not-an-agent-transcript.jsonl",
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
+    func testHideModePpidFallbackSuppressesChildWithoutTranscript() throws {
+        try withPluginSessionMode("hide") {
+            let ppid = 56_004
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let server = HookServer(appState: appState)
+            let payload: [String: Any] = [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ]
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let routed = server.routeSubsessionPayloadIfNeededForTesting(data: data)
+            XCTAssertNotNil(routed.responseData)
+            XCTAssertEqual(routed.processedData, data)
+        }
+    }
+
+    // MARK: - Parent selection
+
+    func testMergeModePpidFallbackLeavesChildWhenMultipleSameSourceParents() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_005
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(-120)
+            )
+            appState.sessions[otherId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date()
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            // Ambiguous IDE process — do not guess which chat owns the Task.
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    func testMergeModePpidFallbackSkipsIdleParent() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_006
+            let appState = AppState()
+            var idle = makeRunningCursorSession(cliPid: ppid)
+            idle.status = .idle
+            appState.sessions[parentId] = idle
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    func testMergeModePpidFallbackSkipsStaleParentActivity() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_007
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(-400)
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    func testMergeModePpidFallbackCursorCliPrefersExactSourceThenSibling() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_008
+            let appState = AppState()
+            // Only IDE cursor parent — cursor-cli child should still find sibling.
+            appState.sessions[parentId] = makeRunningCursorSession(source: "cursor", cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor-cli",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
+    func testMergeModePpidFallbackPrefersExactSourceOverSibling() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_009
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(
+                source: "cursor",
+                cliPid: ppid,
+                lastActivity: Date()
+            )
+            appState.sessions[otherId] = makeRunningCursorSession(
+                source: "cursor-cli",
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(10)
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            // Exact source wins even if sibling is slightly more recent.
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+        }
+    }
+
+    // MARK: - Safety: must not ppid-fold main chat / separate mode
+
+    func testMergeModeDoesNotPpidFoldMainChatWithTranscriptParent() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_010
+            let path = "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/\(parentId).jsonl"
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+            appState.sessions[otherId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(5)
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": parentId,
+                "transcript_path": path,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    func testSeparateModeDoesNotApplyPpidFallback() throws {
+        try withPluginSessionMode("separate") {
+            let ppid = 56_011
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+            XCTAssertNil(routed.responseData)
+        }
+    }
+
+    func testMergeModeWithoutMatchingParentLeavesChildUnchanged() throws {
+        try withPluginSessionMode("merge") {
+            let appState = AppState()
+            // Wrong pid / no sessions.
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": 56_012,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    // MARK: - Transcript fold still preferred when path is foldable
+
+    func testMergeModeTranscriptFoldPreferredOverPpid() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_013
+            let path = "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/\(parentId).jsonl"
+            let appState = AppState()
+            // More recent "distractor" same pid — transcript fold must still win.
+            appState.sessions[parentId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(-30)
+            )
+            appState.sessions[otherId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date()
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "transcript_path": path,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
+    func testMergeModeTranscriptFoldResolvesProviderSessionIdToAppStateKey() throws {
+        try withPluginSessionMode("merge") {
+            let providerUUID = parentId
+            let appKey = "cursor-app:\(providerUUID)"
+            let path = "/Users/u/.cursor/projects/x/agent-transcripts/\(providerUUID)/\(providerUUID).jsonl"
+            let appState = AppState()
+            appState.sessions[appKey] = makeRunningCursorSession(
+                cliPid: 56_014,
+                providerSessionId: providerUUID
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "transcript_path": path,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, appKey)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
+        }
+    }
+
+    func testMergeModePpidFallbackAcceptsStringPpid() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_015
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": "\(ppid)",
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+        }
+    }
+
+    func testMergeModePpidFallbackRejectsZeroPpid() throws {
+        try withPluginSessionMode("merge") {
+            let appState = AppState()
+            var weird = makeRunningCursorSession(cliPid: 0)
+            weird.cliPid = 0
+            appState.sessions[parentId] = weird
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": 0,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    func testMergeModePpidFallbackAllowsWaitingApprovalParent() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_016
+            let appState = AppState()
+            var waiting = makeRunningCursorSession(cliPid: ppid)
+            waiting.status = .waitingApproval
+            appState.sessions[parentId] = waiting
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+        }
+    }
+
+    func testMergeModePpidFallbackLeavesChildWhenEqualActivityAmbiguous() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_017
+            let sharedActivity = Date()
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: sharedActivity
+            )
+            appState.sessions[otherId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: sharedActivity
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    func testMergeModeWithoutPpidKeyDoesNotForceCursorParseForSourceOnlyPayload() throws {
+        try withPluginSessionMode("merge") {
+            // No agent-transcripts and no _ppid key → ppid fallback probe must stay cold.
+            let data = Data(#"{"_source":"cursor","session_id":"abc","hook_event_name":"PostToolUse"}"#.utf8)
+            XCTAssertFalse(HookServer.mayNeedCursorSubsessionRouting(data: data))
+            XCTAssertTrue(HookServer.mayBeCursorHookSource(data: data))
+            // Gate used by routeSubsessionPayloadIfNeeded: source alone is not enough.
+            XCTAssertNil(data.range(of: Data(#""_ppid""#.utf8)))
+        }
+    }
+}

--- a/Tests/CodeIslandTests/HookServerCursorPpidFallbackTests.swift
+++ b/Tests/CodeIslandTests/HookServerCursorPpidFallbackTests.swift
@@ -157,7 +157,7 @@ final class HookServerCursorPpidFallbackTests: XCTestCase {
         }
     }
 
-    func testMergeModePpidFallbackSkipsIdleParent() throws {
+    func testMergeModePpidFallbackAcceptsUniqueIdleParent() throws {
         try withPluginSessionMode("merge") {
             let ppid = 56_006
             let appState = AppState()
@@ -171,8 +171,85 @@ final class HookServerCursorPpidFallbackTests: XCTestCase {
                 "_ppid": ppid,
                 "hook_event_name": "PostToolUse",
             ])
-            XCTAssertEqual(routed.raw["session_id"] as? String, childId)
-            XCTAssertNil(routed.raw["_cursor_subagent"])
+            // Unique same-pid card — idle main is still a valid fold target.
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
+    /// Idle main + running orphan Task sharing the IDE pid: must fold onto the
+    /// main card, never treat the orphan Task as parent.
+    func testMergeModePpidFallbackPrefersIdleMainOverRunningOrphanTask() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_022
+            let orphanTaskId = otherId
+            let newTaskId = childId
+            let appState = AppState()
+
+            var idleMain = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(-60),
+                startTime: Date().addingTimeInterval(-600)
+            )
+            idleMain.status = .idle
+            idleMain.transcriptPath =
+                "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/\(parentId).jsonl"
+            idleMain.providerSessionId = parentId
+            appState.sessions[parentId] = idleMain
+
+            // Orphan Task card still running under the same IDE process.
+            appState.sessions[orphanTaskId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date(),
+                startTime: Date().addingTimeInterval(-30)
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": newTaskId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, newTaskId)
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
+    /// Foldable Task transcript must never win `_ppid` parent selection over a
+    /// same-pid main chat, even when the Task is the only non-idle card.
+    func testMergeModePpidFallbackExcludesFoldableTaskCardAsParent() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_023
+            let orphanTaskId = otherId
+            let appState = AppState()
+
+            var idleMain = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(-90),
+                startTime: Date().addingTimeInterval(-600)
+            )
+            idleMain.status = .idle
+            appState.sessions[parentId] = idleMain
+
+            var orphanTask = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date(),
+                startTime: Date().addingTimeInterval(-20)
+            )
+            orphanTask.transcriptPath =
+                "/Users/u/.cursor/projects/x/agent-transcripts/\(parentId)/subagents/\(orphanTaskId).jsonl"
+            appState.sessions[orphanTaskId] = orphanTask
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
         }
     }
 

--- a/Tests/CodeIslandTests/HookServerCursorPpidFallbackTests.swift
+++ b/Tests/CodeIslandTests/HookServerCursorPpidFallbackTests.swift
@@ -265,6 +265,51 @@ final class HookServerCursorPpidFallbackTests: XCTestCase {
         }
     }
 
+    /// Main chat hooks sometimes omit `transcript_path`. If a sibling Task card
+    /// shares the IDE pid, naive `_ppid` fallback would rewrite the main session
+    /// onto the Task (or tag it as a subagent) and freeze parent chat text.
+    func testMergeModeDoesNotPpidFoldEstablishedMainChatWithoutTranscriptOntoSibling() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_020
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+            appState.sessions[otherId] = makeRunningCursorSession(
+                cliPid: ppid,
+                lastActivity: Date().addingTimeInterval(5)
+            )
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": parentId,
+                "_ppid": ppid,
+                "hook_event_name": "beforeSubmitPrompt",
+                "prompt": "continue the investigation",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertNil(routed.raw["agent_id"])
+            XCTAssertNil(routed.raw["_cursor_subagent"])
+        }
+    }
+
+    /// Unknown Task id (no card yet) must still fold onto the unique parent.
+    func testMergeModeStillPpidFoldsUnknownChildWhenMainCardExists() throws {
+        try withPluginSessionMode("merge") {
+            let ppid = 56_021
+            let appState = AppState()
+            appState.sessions[parentId] = makeRunningCursorSession(cliPid: ppid)
+
+            let routed = try route(appState: appState, payload: [
+                "_source": "cursor",
+                "session_id": childId,
+                "_ppid": ppid,
+                "hook_event_name": "PostToolUse",
+            ])
+            XCTAssertEqual(routed.raw["session_id"] as? String, parentId)
+            XCTAssertEqual(routed.raw["agent_id"] as? String, childId)
+            XCTAssertEqual(routed.raw["_cursor_subagent"] as? Bool, true)
+        }
+    }
+
     func testSeparateModeDoesNotApplyPpidFallback() throws {
         try withPluginSessionMode("separate") {
             let ppid = 56_011

--- a/Tests/CodeIslandTests/HookServerCursorProbeTests.swift
+++ b/Tests/CodeIslandTests/HookServerCursorProbeTests.swift
@@ -48,6 +48,12 @@ final class HookServerCursorProbeTests: XCTestCase {
             "Unrelated _source plus bare cursor text must not force a parse"
         )
 
+        // Misbranded Claude-default Task under ~/.cursor/.../agent-transcripts must parse.
+        let misbrandedCursorPath = Data(
+            #"{"_source":"claude","transcript_path":"/Users/u/.cursor/projects/x/agent-transcripts/p/subagents/c.jsonl"}"#.utf8
+        )
+        XCTAssertTrue(HookServer.mayNeedCursorSubsessionRouting(data: misbrandedCursorPath))
+
         // Non-cursor + agent-transcripts + unrelated `\u` must not claim Cursor.
         let wrongSourceWithUnicodeElsewhere = Data(
             #"{"_source":"claude","text":"\u0041","transcript_path":"\#(path)"}"#.utf8

--- a/Tests/CodeIslandTests/HookServerCursorProbeTests.swift
+++ b/Tests/CodeIslandTests/HookServerCursorProbeTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import CodeIsland
+import CodeIslandCore
 
 @MainActor
 final class HookServerCursorProbeTests: XCTestCase {
@@ -57,5 +58,25 @@ final class HookServerCursorProbeTests: XCTestCase {
 
         let noTranscripts = Data(#"{"_source":"cursor","session_id":"abc"}"#.utf8)
         XCTAssertFalse(HookServer.mayNeedCursorSubsessionRouting(data: noTranscripts))
+        // Without agent-transcripts, source-only probe still sees Cursor (merge/hide gate).
+        XCTAssertTrue(HookServer.mayBeCursorHookSource(data: noTranscripts))
+    }
+
+    func testMayBeCursorHookSourceAcceptsSpacedAndUnicodeWithoutTranscripts() {
+        XCTAssertTrue(
+            HookServer.mayBeCursorHookSource(
+                data: Data(#"{"_source" : "cursor-cli","session_id":"x"}"#.utf8)
+            )
+        )
+        XCTAssertTrue(
+            HookServer.mayBeCursorHookSource(
+                data: Data(#"{"_source":"\u0063ursor","session_id":"x"}"#.utf8)
+            )
+        )
+        XCTAssertFalse(
+            HookServer.mayBeCursorHookSource(
+                data: Data(#"{"_source":"claude","session_id":"x"}"#.utf8)
+            )
+        )
     }
 }

--- a/Tests/CodeIslandTests/MascotSourceConsistencyTests.swift
+++ b/Tests/CodeIslandTests/MascotSourceConsistencyTests.swift
@@ -43,4 +43,24 @@ final class MascotSourceConsistencyTests: XCTestCase {
             "cursor"
         )
     }
+
+    func testTerminalBadgeLabelFollowsCLIWhenHostedInForeignApp() {
+        let session = makeSession(source: "claude", termBundleId: "com.todesktop.230313mzl4w4u92")
+        XCTAssertEqual(session.terminalName, "Cursor")
+        XCTAssertEqual(session.terminalBadgeLabel, "Claude")
+        XCTAssertEqual(session.mascotSource, "claude")
+    }
+
+    func testTerminalBadgeLabelFollowsHostForNativeCursorSession() {
+        let session = makeSession(source: "cursor", termBundleId: "com.todesktop.230313mzl4w4u92")
+        XCTAssertEqual(session.terminalBadgeLabel, "Cursor")
+        XCTAssertEqual(session.mascotSource, "cursor")
+    }
+
+    func testTerminalBadgeLabelInfersCursorWhenSourceEmpty() {
+        let session = makeSession(source: "", termBundleId: "com.todesktop.230313mzl4w4u92")
+        XCTAssertEqual(session.mascotSource, "cursor")
+        XCTAssertEqual(session.terminalBadgeLabel, "Cursor")
+        XCTAssertFalse(session.isCLIHostedInForeignApp)
+    }
 }

--- a/Tests/CodeIslandTests/MascotSourceConsistencyTests.swift
+++ b/Tests/CodeIslandTests/MascotSourceConsistencyTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import CodeIslandCore
+
+/// Left mascot and right host badge must agree on which agent/app a card represents.
+/// Empty hook `source` + Cursor host previously showed Clawd + "Cursor" (#296 follow-up).
+final class MascotSourceConsistencyTests: XCTestCase {
+
+    private func makeSession(source: String, termBundleId: String?) -> SessionSnapshot {
+        var session = SessionSnapshot()
+        session.source = source
+        session.termBundleId = termBundleId
+        return session
+    }
+
+    func testCursorBundleInfersMascotWhenSourceEmpty() {
+        let session = makeSession(source: "", termBundleId: "com.todesktop.230313mzl4w4u92")
+        XCTAssertEqual(session.mascotSource, "cursor")
+        XCTAssertFalse(session.isCLIHostedInForeignApp)
+    }
+
+    func testCursorSourceKeepsCursorMascot() {
+        let session = makeSession(source: "cursor", termBundleId: "com.todesktop.230313mzl4w4u92")
+        XCTAssertEqual(session.mascotSource, "cursor")
+        XCTAssertFalse(session.isCLIHostedInForeignApp)
+    }
+
+    func testClaudeCLIInsideCursorIsForeignHosted() {
+        let session = makeSession(source: "claude", termBundleId: "com.todesktop.230313mzl4w4u92")
+        XCTAssertEqual(session.mascotSource, "claude")
+        XCTAssertTrue(session.isIDETerminal)
+        XCTAssertTrue(session.isCLIHostedInForeignApp)
+    }
+
+    func testCodexDesktopInfersMascotWhenSourceEmpty() {
+        let session = makeSession(source: "", termBundleId: "com.openai.codex")
+        XCTAssertEqual(session.mascotSource, "codex")
+        XCTAssertFalse(session.isCLIHostedInForeignApp)
+    }
+
+    func testSourceForAppBundleIdMapsCursor() {
+        XCTAssertEqual(
+            SessionSnapshot.sourceForAppBundleId("com.todesktop.230313mzl4w4u92"),
+            "cursor"
+        )
+    }
+}


### PR DESCRIPTION
## Depends on

[#285](https://github.com/wxtsky/CodeIsland/pull/285) — merge first; until then the diff vs `main` includes it.

## Summary

- **Cursor merge/hide Tasks without foldable `transcript_path`:** fold (or hide) via a narrow `_ppid` parent fallback — unique same-PID Cursor card only; never guess when ambiguous.
- **Wrong parent under `_ppid`:** prefer the main chat over an orphan Task (including idle mains); never parent onto a foldable Task card.
- **Stale parent chat after merge:** keep folded Task prompts/replies on the parent card; don’t `_ppid`-fold an established main onto a sibling Task; dedupe Cursor transcript vs hook text.
- **Ghost Claude cards from Cursor Tasks:** Claude-format hooks without `--source` no longer leave default-`claude` Task cards beside the real Cursor session — rebrand + fold via Cursor `agent-transcripts` paths.
- **Mascot vs badge mismatch:** Cursor sessions no longer show the default Claude mascot next to a Cursor badge; CLI-in-foreign-IDE badges follow the CLI brand.

## 中文说明

- **无 foldable `transcript_path` 的 Cursor Task：** 用收紧的 `_ppid` 兜底合并/隐藏——只认唯一同 PID 父卡，对不上就不猜。
- **`_ppid` 认错父卡：** 优先主会话（含 idle），不把孤儿 Task 当父卡。
- **合并后父卡对话停更：** 折叠 Task 的问答上浮到父卡；禁止把已有主卡折进 sibling Task；去重 transcript / hook 重复文本。
- **Cursor Task 变成幽灵 Claude 卡：** 无 `--source` 的 Claude 格式 hook 不再留下默认 `claude` 的 Task 卡——按 Cursor `agent-transcripts` 路径重标并折叠。
- **吉祥物与 badge 不一致：** Cursor 会话不再左侧 Claude、右侧 Cursor；CLI 跑在别的 IDE 里时 badge 跟 CLI。

## Test Plan

- [x] `CursorSessionFoldingTests` / `HookServerCursorPpidFallbackTests` / `HookServerCursorProbeTests`
- [x] `AppStateCursorSubsessionTests` — misbranded Claude-default Task rebrand + merge
- [x] `MascotSourceConsistencyTests` / transcript dedupe / Codex reply gate
- [x] Manual — merge/hide Task without foldable `transcript_path`
- [x] Manual — idle main + running orphan Task folds onto main
- [x] Manual — Cursor Task no longer appears as a separate Claude card
- [x] Manual — Cursor mascot + badge both Cursor; Claude-in-Cursor both Claude