### PR TITLE
fix(panel): clamp panel window height to screen (#304)

### DIFF
--- a/Sources/CodeIsland/PanelWindowController.swift
+++ b/Sources/CodeIsland/PanelWindowController.swift
@@ -126,7 +126,15 @@ class PanelWindowController: NSObject, NSWindowDelegate {
 
     private func panelSize(for screen: NSScreen) -> NSSize {
         let maxSessions = CGFloat(max(2, UserDefaults.standard.integer(forKey: SettingsKey.maxVisibleSessions)))
-        let maxH = max(300, maxSessions * 90 + 60)
+        let desiredH = max(300, maxSessions * 90 + 60)
+        // Clamp to the screen's usable height. A borderless, non-opaque panel with a
+        // very tall backing store (e.g. maxVisibleSessions=99 → 8970pt, ~18k px tall on
+        // a Retina display) has its compositing dropped by the macOS 26 WindowServer
+        // once the surface goes idle — the card renders blank until a mouse event forces
+        // a redraw, which looked like "invisible after ~2s, reappears on hover" (#304).
+        // The content is top-anchored and the session list scrolls internally, so the
+        // window never needs to be taller than the visible screen.
+        let maxH = min(desiredH, screen.visibleFrame.height)
         let screenW = screen.frame.width
         let width = min(620, screenW - 40)
         return NSSize(width: width, height: maxH)


### PR DESCRIPTION
Fixes #304.

## Symptom
The Ask-user-question / permission panel becomes invisible ~2s after it appears, on some displays. Moving the mouse over the panel area brings it back; moving away hides it again. Reproduces on the built-in display and one external monitor, but not another external display, across two different MacBook Pros.

## Root cause
The island is a single borderless, non-opaque `NSPanel` whose height is sized up-front to fit the largest possible expanded session list:

```swift
let maxH = max(300, maxSessions * 90 + 60)   // maxVisibleSessions * 90 + 60
```

With a large `maxVisibleSessions` (e.g. 99) this makes the window **8970pt tall** — a ~18k-pixel-tall backing store on a Retina display, for a window that is ~95% transparent and only ever draws content in its top ~200pt.

On macOS 26, the WindowServer drops compositing for a backing store that large once the surface goes idle (to reclaim GPU memory). Nothing in the app forces a repaint of the settled card, so it renders blank until a mouse event forces a recomposition — hence "invisible after ~2s, reappears on hover." It is display-dependent because a 1× (non-HiDPI) external monitor's smaller buffer stays under the purge threshold, which is why one external display was unaffected.

## Fix
Clamp the panel window height to the screen's visible height. The content is top-anchored and the session list already scrolls internally (`ThinScrollView` caps at `maxVisibleSessions * 90`), so the window never needs to be taller than the screen.

## Verification
Confirmed on macOS 26.6 with a release build, using the real hook path (a genuine `AskUserQuestion` over the hook socket), on a Retina display:
- Instrumented the live window: while the card was blank it still reported `isVisible=true`, `alpha=1.0`, `occlusionState.contains(.visible)=true`, surface `.questionCard` — ruling out collapse / `orderOut` / alpha / occlusion-state. The `frame` was 8970pt tall.
- Reducing the window height (via `maxVisibleSessions`) made the card stay visible with nothing else changed.
- With this clamp and `maxVisibleSessions=99`, the card now stays visible for the full duration (previously it vanished after ~2s).