### PR TITLE
feat(badge): show the multiplexer a session runs in next to the terminal

### DIFF
--- a/Sources/CodeIsland/NotchPanelView.swift
+++ b/Sources/CodeIsland/NotchPanelView.swift
@@ -2760,6 +2760,22 @@ private struct TerminalBadge: View {
 
     private let remoteColor = Color(red: 0.3, green: 0.75, blue: 0.5)
 
+    /// Small chip naming the multiplexer the CLI sits in (tmux, zellij), shown
+    /// next to — never instead of — the terminal it runs inside. Same chip
+    /// vocabulary as the queue counter and the AskUserQuestion header.
+    @ViewBuilder
+    private func multiplexerChip(fg: Color, bg: Color) -> some View {
+        if let mux = session.multiplexerLabel {
+            Text(mux)
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(fg)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(bg)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+        }
+    }
+
     var body: some View {
         Group {
             if session.isRemote {
@@ -2772,6 +2788,7 @@ private struct TerminalBadge: View {
                             .font(.system(size: 9.5, weight: .medium, design: .monospaced))
                             .foregroundStyle(remoteColor)
                     }
+                    multiplexerChip(fg: remoteColor, bg: remoteColor.opacity(0.16))
                 }
                 .padding(.horizontal, 6)
                 .padding(.vertical, 3)
@@ -2791,6 +2808,7 @@ private struct TerminalBadge: View {
                             .font(.system(size: 9.5, weight: .medium, design: .monospaced))
                             .foregroundStyle(.white.opacity(0.5))
                     }
+                    multiplexerChip(fg: .white.opacity(0.5), bg: .white.opacity(0.1))
                 }
             }
         }

--- a/Sources/CodeIslandCore/SessionSnapshot.swift
+++ b/Sources/CodeIslandCore/SessionSnapshot.swift
@@ -751,6 +751,18 @@ public struct SessionSnapshot: Sendable {
         return terminalName
     }
 
+    /// The multiplexer layered on top of the terminal, if any.
+    ///
+    /// Not the terminal itself: cmux is a terminal app and is already named by
+    /// `terminalName`, so repeating it here would print the same word twice on
+    /// one badge. Nested multiplexers each leave their env vars behind, so the
+    /// innermost layer — the one the CLI actually sits in — wins.
+    public var multiplexerLabel: String? {
+        if zellijPaneId != nil || zellijSessionName != nil { return "zellij" }
+        if tmuxEnv != nil || tmuxPane != nil { return "tmux" }
+        return nil
+    }
+
     /// Short terminal/app name for display tag
     public var terminalName: String? {
         if isRemote {

--- a/Tests/CodeIslandCoreTests/SessionMultiplexerLabelTests.swift
+++ b/Tests/CodeIslandCoreTests/SessionMultiplexerLabelTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import CodeIslandCore
+
+final class SessionMultiplexerLabelTests: XCTestCase {
+    /// A CLI running under tmux inside iTerm2: the terminal is still iTerm2,
+    /// but the multiplexer layered on top of it must surface separately.
+    func testTmuxInsideATerminalIsReportedAsAMultiplexer() {
+        var snapshot = SessionSnapshot()
+        snapshot.termBundleId = "com.googlecode.iterm2"
+        snapshot.tmuxEnv = "/private/tmp/tmux-501/default,27935,0"
+        snapshot.tmuxPane = "%11"
+
+        XCTAssertEqual(snapshot.multiplexerLabel, "tmux")
+        XCTAssertEqual(snapshot.terminalName, "iTerm2", "the chip augments the terminal name, it never replaces it")
+    }
+
+    func testZellijIsReportedAsAMultiplexer() {
+        var snapshot = SessionSnapshot()
+        snapshot.termBundleId = "com.googlecode.iterm2"
+        snapshot.zellijSessionName = "main"
+        snapshot.zellijPaneId = "3"
+
+        XCTAssertEqual(snapshot.multiplexerLabel, "zellij")
+    }
+
+    /// Nested multiplexers both leave their env vars behind. The innermost one
+    /// is the layer the CLI actually sits in, so that is the one to name.
+    func testNestedMultiplexersReportTheInnermostLayer() {
+        var snapshot = SessionSnapshot()
+        snapshot.termBundleId = "com.googlecode.iterm2"
+        snapshot.tmuxEnv = "/private/tmp/tmux-501/default,27935,0"
+        snapshot.zellijPaneId = "3"
+
+        XCTAssertEqual(snapshot.multiplexerLabel, "zellij")
+    }
+
+    /// cmux is the terminal itself, already named by terminalName. Reporting it
+    /// again as a multiplexer would render the same word twice on one badge.
+    func testCmuxIsNotReportedAsAMultiplexerBecauseItIsTheTerminal() {
+        var snapshot = SessionSnapshot()
+        snapshot.termBundleId = "com.cmux.app"
+        snapshot.cmuxSurfaceId = "6C6E3F2A-0B2E-4F1D-9C55-7A0E2D4B8A31"
+
+        XCTAssertEqual(snapshot.terminalName, "cmux")
+        XCTAssertNil(snapshot.multiplexerLabel)
+    }
+
+    func testAPlainTerminalSessionHasNoMultiplexer() {
+        var snapshot = SessionSnapshot()
+        snapshot.termBundleId = "com.googlecode.iterm2"
+
+        XCTAssertNil(snapshot.multiplexerLabel)
+    }
+}


### PR DESCRIPTION
## Problem

A CLI running under tmux inside iTerm2 is labelled just `iTerm2`. The multiplexer it actually sits in is invisible on the badge, even though several sessions in the same terminal may live in different tmux panes — or different tmux sessions entirely.

The data is already there. From a real `~/.codeisland/sessions.json`:

```json
{"source":"claude", "termApp":"tmux", "termBundleId":"com.googlecode.iterm2",
 "tmuxEnv":"/private/tmp/tmux-501/default,27935,0", "tmuxPane":"%11", ...}
```

`termApp` is `tmux`, and `tmuxEnv` / `tmuxPane` are captured alongside it — `activateTmux` already relies on them for click-to-jump. But `terminalName` resolves from `termBundleId` alone, so it hits `com.googlecode.iterm2` and returns `"iTerm2"`; the multiplexer layer never reaches the badge. Nothing in the collection path needs to change.

## Change

`SessionSnapshot.multiplexerLabel` — the multiplexer layered on top of the terminal — rendered by `TerminalBadge` as a small chip after the terminal name, in the chip vocabulary already used by the queue counter and the `AskUserQuestion` header. Both the local and remote branches of the badge get it: SSH sessions are frequently inside tmux too.

The chip augments the terminal name, never replaces it — you still want to know it's iTerm2.

## Two deliberate exclusions

**cmux is not reported as a multiplexer.** It is a terminal app, already named by `terminalName` (`if lower.contains("cmux") { return "cmux" }`). Reporting it again here would render the same word twice on one badge. There's a regression test pinning this.

**screen is not covered.** `STY` is never captured anywhere in the codebase, so supporting it means touching the hook collection path — a separate change. tmux and zellij both have their env vars already recorded, so they cost nothing.

## Nesting

Nested multiplexers each leave their env vars behind, so `multiplexerLabel` returns the innermost layer — the one the CLI actually sits in. zellij inside tmux reads `zellij`. This matches how click-to-jump already treats the pair (see the zellij-inside-Terax handling in v1.0.31).

## Tests

New `SessionMultiplexerLabelTests`, built test-first:

- tmux inside iTerm2 → `"tmux"`, and `terminalName` still `"iTerm2"` (the chip must not swallow the terminal)
- zellij → `"zellij"`
- zellij nested in tmux → `"zellij"` (innermost wins)
- cmux → `nil`, with `terminalName` asserted as `"cmux"` (pins the no-double-render rule)
- plain terminal → `nil`

Full suite green locally on macOS 26.4 / Xcode 26 (Swift 6.3.3): 890 tests, 2 skipped, 0 failures. `swift build` clean.

## Note

Independent of #325 — different files apart from a non-overlapping region of `NotchPanelView.swift`, and either can merge first.
