### PR TITLE
fix(codex): skip MCP approvals for servers with no declared transport (#328)

### DIFF
--- a/Sources/CodeIsland/CodexPermissionRules.swift
+++ b/Sources/CodeIsland/CodexPermissionRules.swift
@@ -123,6 +123,13 @@ struct CodexPermissionRules {
         do {
             try fileManager.createDirectory(atPath: configDirectory, withIntermediateDirectories: true)
             let existing = (try? String(contentsOfFile: configPath, encoding: .utf8)) ?? ""
+            // Codex rejects the whole config.toml when a `mcp_servers.*` table has
+            // no transport, so a tools table under a server we never declared (the
+            // built-in `codex_app` namespace, say) would break every unrelated
+            // setting. Approve the call in-session instead of persisting it.
+            guard Self.configDeclaresMCPServerTransport(existing, serverID: serverID) else {
+                return false
+            }
             let updated = Self.configWithMCPToolApproval(
                 existing,
                 tablePath: targetPath,
@@ -148,6 +155,22 @@ struct CodexPermissionRules {
         let toolName = String(rest[separator.upperBound...])
         guard !serverID.isEmpty, !toolName.isEmpty else { return nil }
         return (serverID, toolName)
+    }
+
+    static func configDeclaresMCPServerTransport(_ contents: String, serverID: String) -> Bool {
+        let lines = contents.components(separatedBy: .newlines)
+        guard let headerIndex = lines.firstIndex(where: {
+            tomlTableSegments(from: $0) == ["mcp_servers", serverID]
+        }) else {
+            return false
+        }
+
+        let endIndex = lines[(headerIndex + 1)...].firstIndex(where: { tomlTableSegments(from: $0) != nil })
+            ?? lines.endIndex
+        return lines[(headerIndex + 1)..<endIndex].contains { line in
+            guard let key = tomlKey(from: line) else { return false }
+            return key == "command" || key == "url"
+        }
     }
 
     static func configWithMCPToolApproval(_ contents: String, tablePath: [String], comment: String) -> String {

--- a/Tests/CodeIslandTests/AppStatePermissionFlowTests.swift
+++ b/Tests/CodeIslandTests/AppStatePermissionFlowTests.swift
@@ -350,6 +350,14 @@ final class AppStatePermissionFlowTests: XCTestCase {
     func testCodexAlwaysAllowMCPToolPersistsApprovalModeWithoutUnsupportedUpdatedPermissions() async throws {
         let codexHome = makeTemporaryCodexHome()
         defer { try? FileManager.default.removeItem(at: codexHome) }
+        try writeCodexConfig(
+            """
+            [mcp_servers.sh_wiki]
+            command = "sh-wiki-mcp"
+
+            """,
+            in: codexHome
+        )
 
         let appState = AppState()
         let event = try makePermissionRequestEvent(
@@ -508,6 +516,70 @@ final class AppStatePermissionFlowTests: XCTestCase {
         XCTAssertEqual(contents.components(separatedBy: #"pattern = ["npm", "run", "build"]"#).count - 1, 1)
     }
 
+    func testCodexAlwaysAllowPersistsMCPToolForDeclaredServer() throws {
+        let codexHome = makeTemporaryCodexHome()
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+        let configURL = try writeCodexConfig(
+            """
+            [mcp_servers.github]
+            command = "github-mcp-server"
+
+            """,
+            in: codexHome
+        )
+
+        let event = try makePermissionRequestEvent(
+            sessionId: "s-codex-mcp-known",
+            toolName: "mcp__github__get_me",
+            source: "codex"
+        )
+
+        XCTAssertTrue(CodexPermissionRules().persistAlwaysAllowRule(for: event))
+
+        let contents = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertTrue(contents.contains("[mcp_servers.github.tools.get_me]"))
+        XCTAssertTrue(contents.contains(#"approval_mode = "approve""#))
+    }
+
+    /// A tools table under a server that declares no transport makes Codex reject
+    /// the entire config.toml, which surfaces as unrelated settings failing to save.
+    func testCodexAlwaysAllowLeavesConfigUntouchedForUndeclaredMCPServer() throws {
+        let codexHome = makeTemporaryCodexHome()
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+        let original = """
+        [mcp_servers.github]
+        command = "github-mcp-server"
+
+        """
+        let configURL = try writeCodexConfig(original, in: codexHome)
+
+        let event = try makePermissionRequestEvent(
+            sessionId: "s-codex-mcp-unknown",
+            toolName: "mcp__codex_app__send_message_to_thread",
+            source: "codex"
+        )
+
+        XCTAssertFalse(CodexPermissionRules().persistAlwaysAllowRule(for: event))
+
+        let contents = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(contents, original)
+        XCTAssertFalse(contents.contains("codex_app"))
+    }
+
+    func testConfigDeclaresMCPServerTransportRecognisesURLAndRejectsToolsOnlyTable() {
+        let contents = """
+        [mcp_servers.remote]
+        url = "https://example.com/mcp"
+
+        [mcp_servers.codex_app.tools.send_message_to_thread]
+        approval_mode = "approve"
+        """
+
+        XCTAssertTrue(CodexPermissionRules.configDeclaresMCPServerTransport(contents, serverID: "remote"))
+        XCTAssertFalse(CodexPermissionRules.configDeclaresMCPServerTransport(contents, serverID: "codex_app"))
+        XCTAssertFalse(CodexPermissionRules.configDeclaresMCPServerTransport(contents, serverID: "absent"))
+    }
+
     func testCodexAutoReviewConfigDefersPermissionRequestToCodex() throws {
         let codexHome = makeTemporaryCodexHome()
         defer { try? FileManager.default.removeItem(at: codexHome) }
@@ -581,6 +653,14 @@ final class AppStatePermissionFlowTests: XCTestCase {
 
     private func readCodeIslandRules(in codexHome: URL) throws -> String {
         try String(contentsOf: codeIslandRulesPath(in: codexHome), encoding: .utf8)
+    }
+
+    @discardableResult
+    private func writeCodexConfig(_ contents: String, in codexHome: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        let configURL = codexHome.appendingPathComponent("config.toml")
+        try contents.write(to: configURL, atomically: true, encoding: .utf8)
+        return configURL
     }
 
     /// #309 — a dismissed request stays queued so the CLI stays blocked, which


### PR DESCRIPTION
Fixes #328

  ## 问题

  对 `codex_app` 命名空间下的工具点击「Always Allow」后，CodeIsland 会向
  `~/.codex/config.toml` 追加 `[mcp_servers.codex_app.tools.<tool>]`。但
  `codex_app` 是 Codex 桌面端的内置工具命名空间，不是外部 MCP server，配置里
  没有对应的 `[mcp_servers.codex_app]` 定义。这次写入隐式创建出一张只有
  `tools` 子表、没有 transport 字段的表，Codex 加载时直接判定整份配置无效：

  > Invalid configuration: invalid transport in `mcp_servers.codex_app`

  后果是全局的：症状表现为「模型设置保存失败」这类和 MCP 毫无关系的功能异常，
  用户很难联想到是几天前点的一次「Always Allow」。手动删掉那 3 行能恢复，但只要
  再点一次就复发；也无法靠补写 `[mcp_servers.codex_app]` 绕过——该表已被隐式
  创建，再显式声明会触发 TOML 重复定义错误，而 `enabled` 又不提供 transport。

  复现环境：CodeIsland 1.0.32 / Codex 桌面端 26.707.72221 / app-server
  0.150.0-alpha.8 / macOS 15.6 arm64。

  ## 改动

  `CodexPermissionRules.persistAlwaysAllowRule` 在写盘前先确认目标 server 在
  config.toml 中已有带 transport（`command` 或 `url`）的定义：

  - 已声明（如 `github`、`serena`）：按原逻辑写入，行为不变
  - 未声明（如 `codex_app`）：跳过写入，本次调用仍在当前会话内放行

  新增 `configDeclaresMCPServerTransport(_:serverID:)`，定位 `[mcp_servers.<id>]`
  表头后在该表范围内查找 `command` / `url` 键。



  ## 测试

  - `testCodexAlwaysAllowPersistsMCPToolForDeclaredServer`：已声明 server 仍正常写入
  - `testCodexAlwaysAllowLeavesConfigUntouchedForUndeclaredMCPServer`：未声明 server 授权后 config.toml 逐字节不变
  - `testConfigDeclaresMCPServerTransportRecognisesURLAndRejectsToolsOnlyTable`：`url` 也算 transport；只有 tools
  子表的不算
  - 原有的 MCP 测试从空 `CODEX_HOME` 起步，这对真实外部 server 不可能发生（它的工具只有在 config.toml
  声明后才可达），因此改为先写入所要验证的 server